### PR TITLE
Tweak and expand navigation interception

### DIFF
--- a/README.md
+++ b/README.md
@@ -818,9 +818,9 @@ for their help in exploring this space and providing feedback.
 
 ## Appendix: types of navigations
 
-The web platform has many ways of initiating a navigation. For the purposes of this API, and in particular the [`navigate` event](#navigation-monitoring-and-interception), the following is intended to be a comprehensive list:
+The web platform has many ways of initiating a navigation. For the purposes of the app history API, the following is intended to be a comprehensive list:
 
-- Users triggering navigations via browser UI, including (but not necessarily limited to):
+- Users can trigger navigations via browser UI, including (but not necessarily limited to):
   - The URL bar
   - The back and forward buttons
   - The reload button
@@ -853,8 +853,8 @@ Here's a summary table:
 
 |Trigger|Cross- vs. same-document|Fires `navigate`?|`event.userInitiated`|
 |-------|------------------------|-----------------|---------------------|
-|Browser UI (fragment change only)|Always same|Yes|Yes|
-|Browser UI (other)|Always cross|No|—|
+|Browser UI (URL bar fragment change only)|Always same|Yes|Yes|
+|Browser UI (other)|Either|No|—|
 |`<a>`/`<area>`|Either|Yes|Yes|
 |`<form>`|Either|Yes|Yes|
 |`<meta http-equiv="refresh">`|Either|Yes|No|
@@ -867,6 +867,8 @@ Here's a summary table:
 |`appHistory.{back,forward,navigateTo}()`|Either|Yes|No|
 |`appHistory.{pushNewEntry,updateCurrentEntry}()`|Always same|Yes|No|
 |`document.open()`|Always same|Yes|No|
+
+(Regarding the "No" values for the "Fires `navigate`?" column: recall that we need to disallow abusive pages from trapping the user by intercepting the back button. To get notified of such non-interceptable cases after the fact, you can use `currententrychange` for same-document navigations, or the `Window` object's `load` event for cross-document navigations.)
 
 _Spec details: the above comprehensive list does not fully match when the HTML Standard's [navigate](https://html.spec.whatwg.org/#navigate) algorithm is called. In particular, HTML does not handle non-fragment-related same-document navigations through the navigate algorithm; instead it uses the [URL and history update steps](https://html.spec.whatwg.org/#url-and-history-update-steps) for those. Also, HTML calls the navigate algorithm for the initial loads of new browsing contexts as they transition from the initial `about:blank`; our current thinking is that `appHistory` should just not work on the initial `about:blank` so we can avoid that edge case._
 

--- a/README.md
+++ b/README.md
@@ -869,7 +869,7 @@ Here's a summary table:
 |`appHistory.{pushNewEntry,updateCurrentEntry}()`|Always same|Yes|No|
 |`document.open()`|Always same|Yes|No|
 
-(Regarding the "No" values for the "Fires `navigate`?" column: recall that we need to disallow abusive pages from trapping the user by intercepting the back button. To get notified of such non-interceptable cases after the fact, you can use `currententrychange` for same-document navigations, or the `Window` object's `load` event for cross-document navigations.)
+(Regarding the "No" values for the "Fires `navigate`?" column: recall that we need to disallow abusive pages from trapping the user by intercepting the back button. To get notified of such non-interceptable cases after the fact, you can use `currententrychange`.)
 
 _Spec details: the above comprehensive list does not fully match when the HTML Standard's [navigate](https://html.spec.whatwg.org/#navigate) algorithm is called. In particular, HTML does not handle non-fragment-related same-document navigations through the navigate algorithm; instead it uses the [URL and history update steps](https://html.spec.whatwg.org/#url-and-history-update-steps) for those. Also, HTML calls the navigate algorithm for the initial loads of new browsing contexts as they transition from the initial `about:blank`; our current thinking is that `appHistory` should just not work on the initial `about:blank` so we can avoid that edge case._
 

--- a/README.md
+++ b/README.md
@@ -231,6 +231,7 @@ Note that you can check if the navigation will be [same-document or cross-docume
 The event is not fired in the following cases:
 
 - User-initiated cross-document navigations via browser UI, such as the URL bar or bookmarks.
+- User-initiated same-document navigations via the browser back/forward buttons.
 - Programmatically-initiated cross-document navigations originating from other windows, such as `window.open(url, "nameOfAnotherWindow")`.
 
 Whenever it is fired, the event is cancelable via `event.preventDefault()`, which prevents the navigation from going through. To name a few notable examples of when the event is fired, i.e. when you can intercept the navigation:
@@ -853,7 +854,7 @@ Here's a summary table:
 
 |Trigger|Cross- vs. same-document|Fires `navigate`?|`event.userInitiated`|
 |-------|------------------------|-----------------|---------------------|
-|Browser UI (URL bar fragment change only)|Always same|Yes|Yes|
+|Browser UI (non-back/forward fragment change only)|Always same|Yes|Yes|
 |Browser UI (other)|Either|No|—|
 |`<a>`/`<area>`|Either|Yes|Yes|
 |`<form>`|Either|Yes|Yes|

--- a/security-privacy-questionnaire.md
+++ b/security-privacy-questionnaire.md
@@ -48,7 +48,7 @@ No.
 
 **Do features in this specification allow an origin some measure of control over a user agent’s native UI?**
 
-Importantly, no. Navigations through native UI such as the URL bar or back button do not trigger a cancelable `navigate` event. See also the section ["Impact on the back button and user agent UI"](./README.md#impact-on-the-back-button-and-user-agent-ui) for more discussion.
+Importantly, no. Navigations through native UI such as the URL bar or back button do not trigger a cancelable `navigate` event. See the abuse prevention discussion in the ["Navigation monitoring and interception"](./README.md#navigation-monitoring-and-interception) section as well as the ["Impact on the back button and user agent UI"](./README.md#impact-on-the-back-button-and-user-agent-ui) section.
 
 **What temporary identifiers do the features in this specification create or expose to the web?**
 


### PR DESCRIPTION
The normative change here is to resolve "TODO: should the event even fire at all, for these latter two cases?" in the negative: i.e., the navigate event will not fire at all for non-interceptable cases. Additionally, this makes same-document fragment navigations, even initiated via browser UI or window.open(), interceptable.

Beyond that, this commit:

* Expands the discussion of navigation interception to be clearer about what "user-initiated" means
* Adds an appendix detailing all the navigations on the platform, the distinction between cross-document and same-document (closes #3), and a summary table listing how this spec works for each type.
* Discusses the connection between the navigations we're considering, and the HTML Standard algorithms.

/cc @matt-buland-sfdc and @natechapin; I'll probably let this sit for a day or two before merging in case you have any comments.