### PR TITLE
Initial draft of navigate event spec

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -236,7 +236,7 @@ An {{AppHistoryNavigateEvent}} has an associated [=URL=] <dfn for="AppHistoryNav
 <hr>
 
 <div algorithm="fire a navigate event">
-  To <dfn>fire a `navigate` event</dfn> at an {{AppHistory}} |appHistory| given a [=URL=] |destinationURL|, an optional boolean <dfn for="fire a navigate event">|isPush|</dfn>, an optional boolean <dfn for="fire a navigate event">|isCrossDocument|</dfn>, an optional boolean <dfn for="fire a navigate event">|isBackForward|</dfn> (default false), an optional [=user navigation involvement=] <dfn for="fire a navigate event">|userInvolvement|</dfn> (default "<code>[=user navigation involvement/none=]</code>"), an optional boolean <dfn for="fire a navigate event">|isFragmentNavigation|</dfn> (default false), an optional value |navigateInfo| (default null), an optional [=list=] of [=FormData/entries=] or null <dfn for="fire a navigate event">|formDataEntryList|</dfn> (default null), an optional [=serialized state=]-or-null <dfn for="fire a navigate event">|classicHistoryAPISerializedData|</dfn> (default null), and an optional string-or-null <dfn for="fire a navigate event">|classicHistoryAPITitle|</dfn> (default null):
+  To <dfn>fire a `navigate` event</dfn> at an {{AppHistory}} |appHistory| given a [=URL=] |destinationURL|, a boolean <dfn for="fire a navigate event">|isPush|</dfn>, a boolean <dfn for="fire a navigate event">|isCrossDocument|</dfn>, an optional [=user navigation involvement=] <dfn for="fire a navigate event">|userInvolvement|</dfn> (default "<code>[=user navigation involvement/none=]</code>"), an optional boolean <dfn for="fire a navigate event">|isHistoryTraversal|</dfn> (default false), an optional boolean <dfn for="fire a navigate event">|isFragmentNavigation|</dfn> (default false), an optional value |navigateInfo| (default null), an optional [=list=] of [=FormData/entries=] or null <dfn for="fire a navigate event">|formDataEntryList|</dfn> (default null), an optional [=serialized state=]-or-null <dfn for="fire a navigate event">|classicHistoryAPISerializedData|</dfn> (default null), and an optional string-or-null <dfn for="fire a navigate event">|classicHistoryAPITitle|</dfn> (default null):
 
   1. Let |event| be the result of [=creating an event=] given {{AppHistoryNavigateEvent}}, in the [=relevant Realm=] of |appHistory|.
   1. Set |event|'s [=AppHistoryNavigateEvent/destination URL=] to |destinationURL|.
@@ -248,14 +248,12 @@ An {{AppHistoryNavigateEvent}} has an associated [=URL=] <dfn for="AppHistoryNav
   1. Initialize |event|'s {{AppHistoryNavigateEvent/signal}} to a [=new=] {{AbortSignal}} created in the [=relevant Realm=] of |appHistory|.
   1. Initialize |event|'s {{AppHistoryNavigateEvent/info}} to |navigateInfo|.
   1. Let |currentURL| be |appHistory|'s [=relevant global object=]'s [=associated document=]'s [=Document/URL=].
-  1. If |destinationURL| is [=rewritable=] relative to |currentURL|, and either |isCrossDocument| is false or |isBackForward| is false, then initialize |event|'s {{AppHistoryNavigateEvent/canRespond}} to true. Otherwise, initialize it to false.
-  1. If either |userInvolvement| is not "<code>[=user navigation involvement/browser UI=]</code>" or |isBackForward| is false, then initialize |event|'s {{Event/cancelable}} to true.
+  1. If |destinationURL| is [=rewritable=] relative to |currentURL|, and either |isCrossDocument| is false or |isHistoryTraversal| is false, then initialize |event|'s {{AppHistoryNavigateEvent/canRespond}} to true. Otherwise, initialize it to false.
+  1. If either |userInvolvement| is not "<code>[=user navigation involvement/browser UI=]</code>" or |isHistoryTraversal| is false, then initialize |event|'s {{Event/cancelable}} to true.
   1. If |userInvolvement| is "<code>[=user navigation involvement/none=]</code>", then initialize |event|'s {{AppHistoryNavigateEvent/userInitiated}} to false. Otherwise, initialize it to true.
   1. If |formDataEntryList| is not null, then initialize |event|'s {{AppHistoryNavigateEvent/formData}} to a [=new=] {{FormData}} created in the [=relevant Realm=] of |appHistory|, associated to |formDataEntryList|. Otherwise, initialize it to null.
   1. Return the result of [=dispatching=] |event| at |appHistory|.
 </div>
-
-TODO should canRespond become false after calling respondWith? Should it incorporate the other error conditions?
 
 <!-- Remember to modify pushState()/replaceState() to use this, when we eventually move to the HTML Standard. -->
 A [=URL=] is <dfn>rewritable</dfn> relative to another [=URL=] if they differ in only the [=url/path=], [=url/query=], or [=url/fragment=] components.
@@ -372,7 +370,7 @@ With the above infrastructure in place, we can actually fire and handle the {{Ap
   1. If <var ignore>historyHandling</var> is not "<a for="history handling behavior">`entry update`</a>", and <var ignore>userInvolvement</var> is not "<code>[=user navigation involvement/browser UI=]</code>", then:
     1. Let |appHistory| be <var ignore>browsingContext</var>'s [=browsing context/active window=]'s [=Window/app history=].
     1. Let |isPush| be true if <var ignore>historyHandling</var> is "<a for="history handling behavior">`default`</a>"; otherwise, false.
-    1. Let |continue| be the result of [=firing a navigate event=] at |appHistory| given <var ignore>url</var>, with <i>[=fire a navigate event/isPush=]</i> set to |isPush|, <i>[=fire a navigate event/userInvolvement=]</i> set to |userInvolvement|, <i>[=fire a navigate event/isCrossDocument=]</i> set to true, and <i>[=fire a navigate event/formDataEntryList=]</i> set to |entryList|.
+    1. Let |continue| be the result of [=firing a navigate event=] at |appHistory| given <var ignore>url</var>, with <i>[=fire a navigate event/isPush=]</i> set to |isPush|, <i>[=fire a navigate event/isCrossDocument=]</i> set to true, <i>[=fire a navigate event/userInvolvement=]</i> set to |userInvolvement|, and <i>[=fire a navigate event/formDataEntryList=]</i> set to |entryList|.
     1. If |continue| is false, return.
 
     <p class="note">"<code>[=user navigation involvement/browser UI=]</code>" navigations that cause <a spec="HTML" lt="navigate to a fragment">fragment navigations</a> <em>do</em> fire the {{AppHistory/navigate}} event; those are handled as part of the <a spec="HTML">navigate to a fragment</a> algorithm called earlier in <a spec="HTML">navigate</a>, which is not guarded by this condition.
@@ -387,6 +385,6 @@ With the above infrastructure in place, we can actually fire and handle the {{Ap
 
   1. Let |appHistory| be <var ignore>specified browsing context</var>'s [=browsing context/active window=]'s [=Window/app history=].
   1. Let |isCrossDocument| be true if <var ignore>specified browsing context</var>'s [=active document=] is different from <var ignore>specified entry</var>'s [=session history entry/document=]; otherwise, false.
-  1. Let |continue| be the result of [=firing a navigate event=] at |appHistory| given <var ignore>url</var>, with <i>[=fire a navigate event/isPush=]</i> set to false, <i>[=fire a navigate event/isBackForward=]</i> set to true, <i>[=fire a navigate event/isCrossDocument=]</i> set to |isCrossDocument|, and <i>[=fire a navigate event/userInvolvement=]</i> set to |userInvolvement|.
+  1. Let |continue| be the result of [=firing a navigate event=] at |appHistory| given <var ignore>url</var>, with <i>[=fire a navigate event/isPush=]</i> set to false, <i>[=fire a navigate event/isCrossDocument=]</i> set to |isCrossDocument|, <i>[=fire a navigate event/userInvolvement=]</i> set to |userInvolvement|, and <i>[=fire a navigate event/isHistoryTraversal=]</i> set to true.
   1. If |continue| is false, abort these steps.
 </div>

--- a/spec.bs
+++ b/spec.bs
@@ -33,6 +33,9 @@ spec: html; type: dfn; urlPrefix: https://html.spec.whatwg.org/multipage/
     text: document; url: history.html#she-document
   for: history handling behavior
     text: default; url: browsing-the-web.html#hh-default
+  for: navigate
+    text: historyHandling; url: browsing-the-web.html#navigation-hh
+    text: navigationType; url: browsing-the-web.html#navigation-navigationtype
 </pre>
 
 <style>
@@ -178,7 +181,7 @@ dictionary AppHistoryNavigateEventInit : EventInit {
 
   <dt><code>event . {{AppHistoryNavigateEvent/formData}}</code>
   <dd>
-    <p>The {{FormData}} representing the submitted form entries for this navigation, if this navigation was a <a spec="HTML" lt="submit">form submission</a>; null otherwise.
+    <p>The {{FormData}} representing the submitted form entries for this navigation, if this navigation is a POST <a spec="HTML" lt="submit">form submission</a>; null otherwise.
   </dd>
 
   <dt><code>event . {{AppHistoryNavigateEvent/info}}</code>
@@ -219,7 +222,7 @@ An {{AppHistoryNavigateEvent}} has an associated [=URL=] <dfn for="AppHistoryNav
 <hr>
 
 <div algorithm="fire a navigate event">
-  To <dfn>fire a `navigate` event</dfn> at an {{AppHistory}} |appHistory| given a [=URL=] |destinationURL|, a boolean <dfn for="fire a navigate event">|isPush|</dfn>, a boolean <dfn for="fire a navigate event">|isCrossDocument|</dfn>, a boolean <dfn for="fire a navigate event">|isBackForward|</dfn> (default false), a boolean <dfn for="fire a navigate event">|isBrowserUI|</dfn> (default false), a boolean <dfn for="fire a navigate event">|isUserInitiated|</dfn> (default false), a boolean <dfn for="fire a navigate event">|isFragmentNavigation|</dfn> (default false), an optional value |navigateInfo| (default null), an optional [=list=] of [=FormData/entries=] |formDataEntryList|, an optional [=serialized state=]-or-null <dfn for="fire a navigate event">|classicHistoryAPISerializedData|</dfn> (default null), and an optional string-or-null <dfn for="fire a navigate event">|classicHistoryAPITitle|</dfn> (default null):
+  To <dfn>fire a `navigate` event</dfn> at an {{AppHistory}} |appHistory| given a [=URL=] |destinationURL|, a boolean <dfn for="fire a navigate event">|isPush|</dfn>, a boolean <dfn for="fire a navigate event">|isCrossDocument|</dfn>, a boolean <dfn for="fire a navigate event">|isBackForward|</dfn> (default false), a boolean <dfn for="fire a navigate event">|isBrowserUI|</dfn> (default false), a boolean <dfn for="fire a navigate event">|isUserInitiated|</dfn> (default false), a boolean <dfn for="fire a navigate event">|isFragmentNavigation|</dfn> (default false), an optional value |navigateInfo| (default null), an optional [=list=] of [=FormData/entries=] or null <dfn for="fire a navigate event">|formDataEntryList|</dfn> (default null), an optional [=serialized state=]-or-null <dfn for="fire a navigate event">|classicHistoryAPISerializedData|</dfn> (default null), and an optional string-or-null <dfn for="fire a navigate event">|classicHistoryAPITitle|</dfn> (default null):
 
   1. Let |event| be the result of [=creating an event=] given {{AppHistoryNavigateEvent}}, in the [=relevant Realm=] of |appHistory|.
   1. Set |event|'s [=AppHistoryNavigateEvent/destination URL=] to |destinationURL|.
@@ -234,7 +237,7 @@ An {{AppHistoryNavigateEvent}} has an associated [=URL=] <dfn for="AppHistoryNav
   1. Let |currentURL| be |appHistory|'s [=relevant global object=]'s [=associated document=]'s [=Document/URL=].
   1. If |destinationURL| is [=rewritable=] relative to |currentURL|, and either |isCrossDocument| is false or |isBackForward| is false, then initialize |event|'s {{AppHistoryNavigateEvent/canRespond}} to true. Otherwise, initialize it to false.
   1. If either |isBrowserUI| is false or |isBackForward| is false, then initialize |event|'s {{Event/cancelable}} to true.
-  1. If |formDataEntryList| is given, then initialize |event|'s {{AppHistoryNavigateEvent/formData}} to a [=new=] {{FormData}} created in the [=relevant Realm=] of |appHistory|, associated to |formDataEntryList|. Otherwise, initialize it to null.
+  1. If |formDataEntryList| is not null, then initialize |event|'s {{AppHistoryNavigateEvent/formData}} to a [=new=] {{FormData}} created in the [=relevant Realm=] of |appHistory|, associated to |formDataEntryList|. Otherwise, initialize it to null.
   1. Return the result of [=dispatching=] |event| at |appHistory|.
 </div>
 
@@ -274,20 +277,18 @@ TODO what about the last three steps of the <a spec="HTML">shared history push/r
   1. If |continue| is false, return.
 </div>
 
-<div algorithm="navigate">
+<div algorithm="navigate" id="navigate-modifications">
   Modify the <a spec="HTML">navigate</a> algorithm by inserting the following step right before the step which goes [=in parallel=]:
 
   1. If this navigation was not initiated by the user explictly causing <var ignore>browsingContext</var> to navigate using [=user agent=]-specific mechanisms, but instead was initiated by algorithms elsewhere in this specification, then:
     1. Let |appHistory| be <var ignore>browsingContext</var>'s [=browsing context/active window=]'s [=Window/app history=].
     1. Let |isPush| be true if <var ignore>historyHandling</var> is "<a spec="HTML" for="history handling behavior">`default`</a>"; otherwise, false.
-    1. Let |continue| be the result of [=firing a navigate event=] at |appHistory| given <var ignore>url</var>, with <i>[=fire a navigate event/isPush=]</i> set to |isPush|, <i>[=fire a navigate event/isUserInitiated=]</i> set to ???TODO, and <i>[=fire a navigate event/isCrossDocument=]</i> set to true.
+    1. Let |continue| be the result of [=firing a navigate event=] at |appHistory| given <var ignore>url</var>, with <i>[=fire a navigate event/isPush=]</i> set to |isPush|, <i>[=fire a navigate event/isUserInitiated=]</i> set to ???TODO, <i>[=fire a navigate event/isCrossDocument=]</i> set to true, and <i>[=fire a navigate event/formDataEntryList=]</i> set to <var ignore>entryList</var>.
     1. If |continue| is false, return.
 
     <p class="note">[=User agent=]-specific mechanisms that cause <a spec="HTML" lt="navigate to a fragment">fragment navigations</a> <em>do</em> fire the {{AppHistory/navigate}} event; those are handled as part of the <a spec="HTML">navigate to a fragment</a> algorithm, which does not have this condition.
 
   TODO: exclude `about:blank` initial navigation cases.
-
-  TODO: form data??
 </div>
 
 <div algorithm="traverse the history by a delta">
@@ -298,4 +299,26 @@ TODO what about the last three steps of the <a spec="HTML">shared history push/r
   1. Let |isCrossDocument| be true if <var ignore>specified browsing context</var>'s [=active document=] is different from <var ignore>specified entry</var>'s [=session history entry/document=]; otherwise, false.
   1. Let |continue| be the result of [=firing a navigate event=] at |appHistory| given <var ignore>url</var>, with <i>[=fire a navigate event/isPush=]</i> set to false, <i>[=fire a navigate event/isBackForward=]</i> set to true, <i>[=fire a navigate event/isCrossDocument=]</i> set to |isCrossDocument|, and <i>[=fire a navigate event/isBrowserUI=]</i> and <i>[=fire a navigate event/isUserInitiated=]</i> both set to |isBrowserUI|.
   1. If |continue| is false, abort these steps.
+</div>
+
+<h3 id="form-patches">Form submission patches</h3>
+
+To properly thread the form entry list from its creation through to {{AppHistoryNavigateEvent}}'s {{AppHistoryNavigateEvent/formData}} property, we need the following modifications:
+
+<div algorithm="form navigate">
+  Modify the <a spec="HTML">navigate</a> algorithm to take a [=list=] of [=FormData/entries=] or null <dfn for="navigate">|entryList|</dfn> (default null), replacing its |navigationType| parameter. Then insert a step somewhere early in the algorithm to convert this back into the |navigationType| variable used by the [=in parallel=] section that is ultimately passed to [[CSP]]:
+
+  1. Let |navigationType| be "`form-submission`" if |entryList| is non-null; otherwise, "`other`".
+
+  Our <a href="navigate-modifications">modifications above</a> then use <i>[=navigate/entryList=]</i>.
+</div>
+
+<div algorithm="plan to navigate">
+  Modify the <a spec="HTML">plan to navigate</a> algorithm to take an additional optional argument |entryList| (default null). Then, modify the step which calls <a spec="HTML">navigate</a> to pass it along:
+
+  1. <a spec="HTML">Navigate</a> <var ignore>target browsing context</var> to <var ignore>destination</var>, with <i>[=navigate/historyHandling=]</i> set to <var ignore>historyHandling</var> <del>and <i>[=navigate/navigationType=]</i> set to "`form-submission`"</del><ins><i>[=navigate/entryList=]</i> set to |entryList|</ins>.
+</div>
+
+<div algorithm="submit as entity body">
+  Modify the <a spec="HTML">submit as entity body</a> algorithm to pass <var ignore>entry list</var> along to <a spec="HTML">plan to navigate</a> as a second argument.
 </div>

--- a/spec.bs
+++ b/spec.bs
@@ -266,8 +266,6 @@ The following section details monkeypatches to [[!HTML]] that cause the {{AppHis
   1. If |continue| is false, return.
 </div>
 
-TODO what about the last three steps of the <a spec="HTML">shared history push/replace state steps</a>? Probably those should run if respondWith() goes through?
-
 <div algorithm="navigate to a fragment">
   Modify the <a spec="HTML">navigate to a fragment</a> algorithm by prepending the following steps:
 

--- a/spec.bs
+++ b/spec.bs
@@ -210,7 +210,7 @@ An {{AppHistoryNavigateEvent}} has an associated [=URL=] <dfn for="AppHistoryNav
   1. If [=this=]'s {{Event/isTrusted}} attribute was initialized to false, then throw a "{{SecurityError}}" {{DOMException}}.
   1. If [=this=]'s {{AppHistoryNavigateEvent/canRespond}} attribute was initialized to false, then throw a "{{SecurityError}}" {{DOMException}}.
   1. If [=this=]'s [=Event/dispatch flag=] is unset, then throw an "{{InvalidStateError}}" {{DOMException}}.
-  1. If [=this=]'s [=Event/canceled flag=] is unset, then throw an "{{InvalidStateError}}" {{DOMException}}.
+  1. If [=this=]'s [=Event/canceled flag=] is set, then throw an "{{InvalidStateError}}" {{DOMException}}.
   1. Set [=this=]'s [=Event/canceled flag=].
   1. Run the <a spec="HTML">URL and history update steps</a> given [=this=]'s [=relevant global object=]'s [=associated document=] and [=this=]'s [=AppHistoryNavigateEvent/destination URL=], with <i>[=URL and history update steps/serializedData=]</i> set to [=this=]'s [=AppHistoryNavigateEvent/classic history API serialized data=], <i>[=URL and history update steps/title=]</i> set to [=this=]'s [=AppHistoryNavigateEvent/classic history API title=], and <i>[=URL and history update steps/isPush=]</i> set to [=this=]'s [=AppHistoryNavigateEvent/is push=].
   1. Let |appHistory| be [=this=]'s [=relevant global object=]'s [=Window/app history=].

--- a/spec.bs
+++ b/spec.bs
@@ -33,6 +33,7 @@ spec: html; type: dfn; urlPrefix: https://html.spec.whatwg.org/multipage/
     text: document; url: history.html#she-document
   for: history handling behavior
     text: default; url: browsing-the-web.html#hh-default
+    text: entry update; url: browsing-the-web.html#hh-entry-update
   for: navigate
     text: historyHandling; url: browsing-the-web.html#navigation-hh
     text: navigationType; url: browsing-the-web.html#navigation-navigationtype
@@ -278,13 +279,15 @@ The following section details monkeypatches to [[!HTML]] that cause the {{AppHis
 <div algorithm="navigate" id="navigate-modifications">
   Modify the <a spec="HTML">navigate</a> algorithm by inserting the following step right before the step which goes [=in parallel=]:
 
-  1. If this navigation was not initiated by the user explictly causing <var ignore>browsingContext</var> to navigate using [=user agent=]-specific mechanisms, but instead was initiated by algorithms elsewhere in this specification, then:
+  1. If <var ignore>historyHandling</var> is not "<a for="history handling behavior">`entry update`</a>", and this navigation was not initiated by the user explictly causing <var ignore>browsingContext</var> to navigate using [=user agent=]-specific mechanisms but instead was initiated by algorithms elsewhere in this specification, then:
     1. Let |appHistory| be <var ignore>browsingContext</var>'s [=browsing context/active window=]'s [=Window/app history=].
-    1. Let |isPush| be true if <var ignore>historyHandling</var> is "<a spec="HTML" for="history handling behavior">`default`</a>"; otherwise, false.
+    1. Let |isPush| be true if <var ignore>historyHandling</var> is "<a for="history handling behavior">`default`</a>"; otherwise, false.
     1. Let |continue| be the result of [=firing a navigate event=] at |appHistory| given <var ignore>url</var>, with <i>[=fire a navigate event/isPush=]</i> set to |isPush|, <i>[=fire a navigate event/isUserInitiated=]</i> set to ???TODO, <i>[=fire a navigate event/isCrossDocument=]</i> set to true, and <i>[=fire a navigate event/formDataEntryList=]</i> set to <var ignore>entryList</var>.
     1. If |continue| is false, return.
 
     <p class="note">[=User agent=]-specific mechanisms that cause <a spec="HTML" lt="navigate to a fragment">fragment navigations</a> <em>do</em> fire the {{AppHistory/navigate}} event; those are handled as part of the <a spec="HTML">navigate to a fragment</a> algorithm, which does not have this condition.
+
+    <p class="note">"<a for="history handling behavior">`entry update`</a>" is excluded since {{AppHistory/navigate}} would have fired earlier as part of <a spec="HTML">traversing the history by a delta</a>.
 
   TODO: exclude `about:blank` initial navigation cases.
 </div>

--- a/spec.bs
+++ b/spec.bs
@@ -305,13 +305,15 @@ Introduce (right before the definition of the <a spec="HTML">navigate</a> algori
 : "<dfn for="user navigation involvement"><code>none</code></dfn>"
 :: The navigation was not initiated by the user
 
+Define the <dfn for="Event">user navigation involvement</dfn> for an {{Event}} |event| as "<code>[=user navigation involvement/activation=]</code>" if |event|'s {{Event/isTrusted}} attribute is initialized to true, and "<code>[=user navigation involvement/none=]</code>" otherwise.
+
 Modify the <a spec="HTML">navigate</a> algorithm to take an optional named argument <dfn for="navigate"><var ignore>userInvolvement</var></dfn> (default "<code>[=user navigation involvement/none=]</code>"). Then, update the paragraph talking about browser-UI initiated navigation as follows:
 
 <blockquote>
   A user agent may provide various ways for the user to explicitly cause a browsing context to <a spec="HTML">navigate</a>, in addition to those defined in this specification.<ins> Such cases must set the <i>[=navigate/userInvolvement=]</i> argument to "<code>[=user navigation involvement/browser UI=]</code>".</ins>
 </blockquote>
 
-<p class="note">This infrastructure partially solves <a href="https://github.com/whatwg/html/issues/5381">whatwg/html#5381</a>, and it'd be ideal to update the \`<a http-header><code>Sec-Fetch-Dest</code></a>\` spec at the same time.</p>
+<p class="note">This infrastructure partially solves <a href="https://github.com/whatwg/html/issues/5381">whatwg/html#5381</a>, and it'd be ideal to update the \`<a http-header><code>Sec-Fetch-Site</code></a>\` spec at the same time.</p>
 
 Modify the <a spec="HTML">navigate to a fragment</a> algorithm to take a new <var ignore>userInvolvement</var> argument. Then, update the call to it from <a spec="HTML">navigate</a> to set <i>[=navigate/userInvolvement=]</i> to this <var ignore>userInvolvement</var> value.
 
@@ -323,31 +325,41 @@ Modify the <a spec="HTML">traverse the history by a delta</a> argument to take a
 
 <hr>
 
-Modify the <a spec="HTML">follows a hyperlink</a> algorithm to take a new <var ignore>userInvolvement</var> argument. Then, update the call to it from <a spec="HTML">navigate</a> to set <i>[=navigate/userInvolvement=]</i> to this <var ignore>userInvolvement</var> value.
+Modify the <a spec="HTML">follow the hyperlink</a> algorithm to take a new <var ignore>userInvolvement</var> argument. Then, update the call to it from <a spec="HTML">navigate</a> to set <i>[=navigate/userInvolvement=]</i> to this <var ignore>userInvolvement</var> value.
 
 <div algorithm="area activation behavior">
-  Modify the [=EventTarget/activation behavior=] of <{area}> elements by introducing the |event| argument and replacing the <a spec="HTML" lt="follows a hyperlink">follow the hyperlink</a> step with the following:
+  Modify the [=EventTarget/activation behavior=] of <{area}> elements by introducing the |event| argument and replacing the <a spec="HTML">follow the hyperlink</a> step with the following:
 
-  1. Otherwise:
-    1. Let |userInvolvement| be "<code>[=user navigation involvement/activation=]</code>" if |event|'s {{Event/isTrusted}} attribute is initialized to true; otherwise, "<code>[=user navigation involvement/none=]</code>".
-    1. <a spec="HTML" lt="follows a hyperlink">Follow the hyperlink</a> created by <var ignore>element</var> with |userInvolvement|.
+  1. Otherwise, <a spec="HTML">follow the hyperlink</a> created by <var ignore>element</var> with the [=Event/user navigation involvement=] for |event|.
 </div>
 
 <div algorithm="a activation behavior">
-  Modify the [=EventTarget/activation behavior=] of <{a}> elements by replacing its <a spec="HTML" lt="follows a hyperlink">follow the hyperlink</a> step with the following:
+  Modify the [=EventTarget/activation behavior=] of <{a}> elements by replacing its <a spec="HTML">follow the hyperlink</a> step with the following:
 
-  1. Otherwise:
-    1. Let |userInvolvement| be "<code>[=user navigation involvement/activation=]</code>" if <var ignore>event</var>'s {{Event/isTrusted}} attribute is initialized to true; otherwise, "<code>[=user navigation involvement/none=]</code>".
-    1. <a spec="HTML" lt="follows a hyperlink">Follow the hyperlink</a> created by <var ignore>element</var> with |userInvolvement|.
+  1. Otherwise, <a spec="HTML">follow the hyperlink</a> created by <var ignore>element</var> with the [=Event/user navigation involvement=] for <var ignore>event</var>.
 </div>
 
 Expand the section on "<a href="https://html.spec.whatwg.org/multipage/semantics.html#providing-users-with-a-means-to-follow-hyperlinks-created-using-the-link-element">Providing users with a means to follow hyperlinks created using the `link` element</a>" by adding the following sentence:
 
-<blockquote><ins>Such invocations of <a spec="HTML" lt="follows a hyperlink">follow the hyperlink</a> algorithm must set the <i>[=navigate/userInvolvement=]</i> argument to "<code>[=user navigation involvement/browser UI=]</code>".</ins></blockquote>
+<blockquote><ins>Such invocations of <a spec="HTML">follow the hyperlink</a> algorithm must set the <i>[=navigate/userInvolvement=]</i> argument to "<code>[=user navigation involvement/browser UI=]</code>".</ins></blockquote>
 
 <hr>
 
-TODO form submission user-initiated.
+Modify the <a spec="HTML">plan to navigate</a> algorithm to take a <var ignore>userInvolvement</var> argument. Then, update the call to it from <a spec="HTML">navigate</a> to set <i>[=navigate/userInvolvement=]</i> to this <var ignore>userInvolvement</var> value.
+
+Modify the <a spec="HTML" lt="submitted">submit</a> algorithm to take an optional <var ignore>userInvolvement</var> argument (default "<code>[=user navigation involvement/none=]</code>").  Have the <a spec="HTML" lt="submitted">submit</a> algorithm pass along its value to all invocations of <a spec="HTML">plan to navigate</a>.
+
+Modify the definition of the [=EventTarget/activation behavior=] for <{input}> elements to take an <var ignore>event</var> argument. Then, pass along this argument to the invocation of the <a spec="HTML">input activation behavior</a>.
+
+Modify the Submit Button state's <a spec="HTML">input activation behavior</a> by having it take an <var ignore>event<var> argument and pass along the [=Event/user navigation involvement=] for <var ignore>event</var> as the final argument when it calls <a spec="HTML" lt="submitted">submit</a>.
+
+Modify the Image Button state's <a spec="HTML">input activation behavior</a> by having it take an <var ignore>event<var> argument and pass along the [=Event/user navigation involvement=] for <var ignore>event</var> as the final argument when it calls <a spec="HTML" lt="submitted">submit</a>.
+
+Modify the <{button}> element's [=EventTarget/activation behavior=] by having it take an <var ignore>event</var> argument and, in the Submit Button case, to pass along the [=Event/user navigation involvement=] for <var ignore>event</var> as the final argument when it calls <a spec="HTML" lt="submitted">submit</a>.
+
+Modify the no-<a spec="HTML">submit button</a> case for <a href="https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#implicit-submission">implicit form submission</a> to pass along "<code>[=user navigation involvement/activation=]</code>" as the final argument when it calls <a spec="HTML" lt="submitted">submit</a>.
+
+<p class="note">The case of implicit submission when a submit button is present is automatically taken care of because it fires a (trusted) click event at the submit button.</p>
 
 <h3 id="navigate-algorithm-patches">Navigation algorithm updates</h3>
 

--- a/spec.bs
+++ b/spec.bs
@@ -150,7 +150,7 @@ interface AppHistoryNavigateEvent : Event {
   readonly attribute boolean userInitiated;
   readonly attribute boolean hashChange;
 //  readonly attribute AppHistoryEntry destination;
-  readonly attribute AbortSignal signal;
+//  readonly attribute AbortSignal signal;
   readonly attribute FormData? formData;
   readonly attribute any info;
 
@@ -162,7 +162,7 @@ dictionary AppHistoryNavigateEventInit : EventInit {
   boolean userInitiated = false;
   boolean hashChange = false;
 //  required AppHistoryEntry destination;
-  required AbortSignal signal;
+//  required AbortSignal signal;
   FormData? formData = null;
   any info = null;
 };
@@ -186,12 +186,14 @@ dictionary AppHistoryNavigateEventInit : EventInit {
     <p>True if this navigation is a <a spec="HTML" lt="navigate to a fragment">fragment navigation</a>; false otherwise.
   </dd>
 
+<!--
   <dt><code>event . {{AppHistoryNavigateEvent/signal}}</code>
   <dd>
     <p>An {{AbortSignal}} which will become aborted if the navigation gets canceled, e.g. by the user pressing their browser's "Stop" button, or another higher-priority navigation interrupting this one.
 
     <p>The expected pattern is for developers to pass this along to any async operations, such as {{WindowOrWorkerGlobalScope/fetch()}}, which they perform as part of handling this navigation.
   </dd>
+-->
 
   <dt><code>event . {{AppHistoryNavigateEvent/formData}}</code>
   <dd>
@@ -213,7 +215,7 @@ dictionary AppHistoryNavigateEventInit : EventInit {
   </dd>
 </dl>
 
-The <dfn attribute for="AppHistoryNavigateEvent">canRespond</dfn>, <dfn attribute for="AppHistoryNavigateEvent">userInitiated</dfn>, <dfn attribute for="AppHistoryNavigateEvent">hashChange</dfn>, <dfn attribute for="AppHistoryNavigateEvent">signal</dfn>, <dfn attribute for="AppHistoryNavigateEvent">formData</dfn>, and <dfn attribute for="AppHistoryNavigateEvent">info</dfn> getter steps are to return the value that the corresponding attribute was initialized to.
+The <dfn attribute for="AppHistoryNavigateEvent">canRespond</dfn>, <dfn attribute for="AppHistoryNavigateEvent">userInitiated</dfn>, <dfn attribute for="AppHistoryNavigateEvent">hashChange</dfn><!--, <dfn attribute for="AppHistoryNavigateEvent">signal</dfn>-->, <dfn attribute for="AppHistoryNavigateEvent">formData</dfn>, and <dfn attribute for="AppHistoryNavigateEvent">info</dfn> getter steps are to return the value that the corresponding attribute was initialized to.
 
 An {{AppHistoryNavigateEvent}} has an associated [=URL=] <dfn for="AppHistoryNavigateEvent">destination URL</dfn>, an associated boolean <dfn for="AppHistoryNavigateEvent">is push</dfn>, an associated [=serialized state=]-or-null <dfn for="AppHistoryNavigateEvent">classic history API serialized data</dfn>, and an optional string-or-null <dfn for="AppHistoryNavigateEvent">classic history API title</dfn>. All of these are set when the event is [=fire a navigate event|fired=].
 
@@ -245,7 +247,7 @@ An {{AppHistoryNavigateEvent}} has an associated [=URL=] <dfn for="AppHistoryNav
   1. Set |event|'s [=AppHistoryNavigateEvent/classic history API title=] to |classicHistoryAPITitle|.
   1. Initialize |event|'s {{Event/type}} to {{AppHistory/navigate}}.
   1. Initialize |event|'s {{AppHistoryNavigateEvent/hashChange}} to |isFragmentNavigation|.
-  1. Initialize |event|'s {{AppHistoryNavigateEvent/signal}} to a [=new=] {{AbortSignal}} created in the [=relevant Realm=] of |appHistory|.
+<!--  1. Initialize |event|'s {{AppHistoryNavigateEvent/signal}} to a [=new=] {{AbortSignal}} created in the [=relevant Realm=] of |appHistory|.-->
   1. Initialize |event|'s {{AppHistoryNavigateEvent/info}} to |navigateInfo|.
   1. Let |currentURL| be |appHistory|'s [=relevant global object=]'s [=associated document=]'s [=Document/URL=].
   1. If |destinationURL| is [=rewritable=] relative to |currentURL|, and either |isCrossDocument| is false or |isHistoryTraversal| is false, then initialize |event|'s {{AppHistoryNavigateEvent/canRespond}} to true. Otherwise, initialize it to false.
@@ -371,17 +373,21 @@ With the above infrastructure in place, we can actually fire and handle the {{Ap
 <div algorithm="navigate" id="navigate-modifications">
   Modify the <a spec="HTML">navigate</a> algorithm by inserting the following step right before the step which goes [=in parallel=]. Recall that per [[#user-initiated-patches]] we have introduced |userInvolvement| argument, and per [[#form-patches]] we have introduced a |entryList| argument.
 
-  1. If <var ignore>historyHandling</var> is not "<a for="history handling behavior">`entry update`</a>", and <var ignore>userInvolvement</var> is not "<code>[=user navigation involvement/browser UI=]</code>", then:
-    1. Let |appHistory| be <var ignore>browsingContext</var>'s [=browsing context/active window=]'s [=Window/app history=].
-    1. Let |isPush| be true if <var ignore>historyHandling</var> is "<a for="history handling behavior">`default`</a>"; otherwise, false.
-    1. Let |continue| be the result of [=firing a navigate event=] at |appHistory| given <var ignore>url</var>, with <i>[=fire a navigate event/isPush=]</i> set to |isPush|, <i>[=fire a navigate event/isCrossDocument=]</i> set to true, <i>[=fire a navigate event/userInvolvement=]</i> set to |userInvolvement|, and <i>[=fire a navigate event/formDataEntryList=]</i> set to |entryList|.
-    1. If |continue| is false, return.
+  1. If none of the following are true:
+    * <var ignore>historyHandling</var> is "<a for="history handling behavior">`entry update`</a>"
+    * <var ignore>userInvolvement</var> is "<code>[=user navigation involvement/browser UI=]</code>"
+    * <var ignore>browsingContext</var>'s only entry in its <a spec="HTML">session history</a> is the `about:blank` {{Document}} that was added when <var ignore>browsingContext</var> was <a spec="HTML" lt="create a new browsing context">created</a>
+
+    then:
+
+      1. Let |appHistory| be <var ignore>browsingContext</var>'s [=browsing context/active window=]'s [=Window/app history=].
+      1. Let |isPush| be true if <var ignore>historyHandling</var> is "<a for="history handling behavior">`default`</a>"; otherwise, false.
+      1. Let |continue| be the result of [=firing a navigate event=] at |appHistory| given <var ignore>url</var>, with <i>[=fire a navigate event/isPush=]</i> set to |isPush|, <i>[=fire a navigate event/isCrossDocument=]</i> set to true, <i>[=fire a navigate event/userInvolvement=]</i> set to |userInvolvement|, and <i>[=fire a navigate event/formDataEntryList=]</i> set to |entryList|.
+      1. If |continue| is false, return.
 
     <p class="note">"<code>[=user navigation involvement/browser UI=]</code>" navigations that cause <a spec="HTML" lt="navigate to a fragment">fragment navigations</a> <em>do</em> fire the {{AppHistory/navigate}} event; those are handled as part of the <a spec="HTML">navigate to a fragment</a> algorithm called earlier in <a spec="HTML">navigate</a>, which is not guarded by this condition.
 
     <p class="note">"<a for="history handling behavior">`entry update`</a>" is excluded since {{AppHistory/navigate}} would have fired earlier as part of <a spec="HTML">traversing the history by a delta</a>.
-
-  TODO: exclude `about:blank` initial navigation cases.
 </div>
 
 <div algorithm="traverse the history by a delta">

--- a/spec.bs
+++ b/spec.bs
@@ -239,7 +239,7 @@ An {{AppHistoryNavigateEvent}} has an associated [=URL=] <dfn for="AppHistoryNav
 <hr>
 
 <div algorithm="fire a navigate event">
-  To <dfn>fire a `navigate` event</dfn> at an {{AppHistory}} |appHistory| given a [=URL=] |destinationURL|, a boolean <dfn for="fire a navigate event">|isPush|</dfn>, a boolean <dfn for="fire a navigate event">|isSameDocument|</dfn>, an optional [=user navigation involvement=] <dfn for="fire a navigate event">|userInvolvement|</dfn> (default "<code>[=user navigation involvement/none=]</code>"), an optional boolean <dfn for="fire a navigate event">|isHistoryTraversal|</dfn> (default false), an optional boolean <dfn for="fire a navigate event">|hashChange|</dfn> (default false), an optional value |navigateInfo| (default null), an optional [=list=] of [=FormData/entries=] or null <dfn for="fire a navigate event">|formDataEntryList|</dfn> (default null), an optional [=serialized state=]-or-null <dfn for="fire a navigate event">|classicHistoryAPISerializedData|</dfn> (default null), and an optional string-or-null <dfn for="fire a navigate event">|classicHistoryAPITitle|</dfn> (default null):
+  To <dfn>fire a `navigate` event</dfn> at an {{AppHistory}} |appHistory| given a [=URL=] |destinationURL|, a boolean <dfn for="fire a navigate event">|isPush|</dfn>, a boolean <dfn for="fire a navigate event">|isSameDocument|</dfn>, an optional [=user navigation involvement=] <dfn for="fire a navigate event">|userInvolvement|</dfn> (default "<code>[=user navigation involvement/none=]</code>"), an optional boolean <dfn for="fire a navigate event">|isHistoryTraversal|</dfn> (default false), an optional value |navigateInfo| (default null), an optional [=list=] of [=FormData/entries=] or null <dfn for="fire a navigate event">|formDataEntryList|</dfn> (default null), an optional [=serialized state=]-or-null <dfn for="fire a navigate event">|classicHistoryAPISerializedData|</dfn> (default null), and an optional string-or-null <dfn for="fire a navigate event">|classicHistoryAPITitle|</dfn> (default null):
 
   1. Let |event| be the result of [=creating an event=] given {{AppHistoryNavigateEvent}}, in the [=relevant Realm=] of |appHistory|.
   1. Set |event|'s [=AppHistoryNavigateEvent/destination URL=] to |destinationURL|.
@@ -247,10 +247,15 @@ An {{AppHistoryNavigateEvent}} has an associated [=URL=] <dfn for="AppHistoryNav
   1. Set |event|'s [=AppHistoryNavigateEvent/classic history API serialized data=] to |classicHistoryAPISerializedData|.
   1. Set |event|'s [=AppHistoryNavigateEvent/classic history API title=] to |classicHistoryAPITitle|.
   1. Initialize |event|'s {{Event/type}} to {{AppHistory/navigate}}.
-  1. Initialize |event|'s {{AppHistoryNavigateEvent/hashChange}} to |hashChange|.
 <!--  1. Initialize |event|'s {{AppHistoryNavigateEvent/signal}} to a [=new=] {{AbortSignal}} created in the [=relevant Realm=] of |appHistory|.-->
   1. Initialize |event|'s {{AppHistoryNavigateEvent/info}} to |navigateInfo|.
   1. Let |currentURL| be |appHistory|'s [=relevant global object=]'s [=associated document=]'s [=Document/URL=].
+  1. If all of the following are true:
+    * |isSameDocument| is true;
+    * |destinationURL| [=url/equals=] |currentURL| with <i>[=url/equals/exclude fragments=]</i> set to true; and
+    * |destinationURL|'s [=url/fragment=] is not [=string/is|identical to=] |currentURL|'s [=url/fragment=]
+
+    then initialize |event|'s {{AppHistoryNavigateEvent/hashChange}} to true. Otherwise, initialize it to false.
   1. If |destinationURL| is [=rewritable=] relative to |currentURL|, and either |isSameDocument| is true or |isHistoryTraversal| is false, then initialize |event|'s {{AppHistoryNavigateEvent/canRespond}} to true. Otherwise, initialize it to false.
   1. If either |userInvolvement| is not "<code>[=user navigation involvement/browser UI=]</code>" or |isHistoryTraversal| is false, then initialize |event|'s {{Event/cancelable}} to true.
   1. If |userInvolvement| is "<code>[=user navigation involvement/none=]</code>", then initialize |event|'s {{AppHistoryNavigateEvent/userInitiated}} to false. Otherwise, initialize it to true.
@@ -379,7 +384,7 @@ With the above infrastructure in place, we can actually fire and handle the {{Ap
 
   1. Let |appHistory| be the <a spec="HTML">current entry</a>'s <a spec="HTML" for="session history entry">document</a>'s [=relevant global object=]'s [=Window/app history=].
   1. Let |isPush| be true if <var ignore>historyHandling</var> is "<a spec="HTML" for="history handling behavior">`default`</a>"; otherwise, false.
-  1. Let |continue| be the result of [=firing a navigate event=] at |appHistory| given <var ignore>url</var>, with <i>[=fire a navigate event/isPush=]</i> set to |isPush|, <i>[=fire a navigate event/isSameDocument=]</i> set to true, <i>[=fire a navigate event/userInvolvement=]</i> set to |userInvolvement|, and <i>[=fire a navigate event/hashChange=]</i> set to true.
+  1. Let |continue| be the result of [=firing a navigate event=] at |appHistory| given <var ignore>url</var>, with <i>[=fire a navigate event/isPush=]</i> set to |isPush|, <i>[=fire a navigate event/isSameDocument=]</i> set to true, and <i>[=fire a navigate event/userInvolvement=]</i> set to |userInvolvement|.
   1. If |continue| is false, return.
 </div>
 
@@ -409,12 +414,6 @@ With the above infrastructure in place, we can actually fire and handle the {{Ap
   1. Let |appHistory| be <var ignore>specified browsing context</var>'s [=browsing context/active window=]'s [=Window/app history=].
   1. Let |isSameDocument| be true if <var ignore>specified browsing context</var>'s [=active document=] equals <var ignore>specified entry</var>'s [=session history entry/document=]; otherwise, false.
   1. If either |isSameDocument| is true or |userInvolvement| is not "<code>[=user navigation involvement/browser UI=]</code>", then:
-    1. Let |hashChange| be true if all of the following are true:
-      * |isSameDocument| is true;
-      * <var ignore>specified browsing context</var>'s [=active document=]'s [=Document/URL=] [=url/equals=] <var ignore>specified entry</var>'s [=session history entry/URL=] with <i>[=url/equals/exclude fragments=]</i> set to true; and
-      * <var ignore>specified browsing context</var>'s [=active document=]'s [=Document/URL=]'s [=url/fragment=] is not [=string/is|identical to=] <var ignore>specified entry</var>'s [=session history entry/URL=]'s [=url/fragment=].
-
-      Otherwise, let it be false.
-    1. Let |continue| be the result of [=firing a navigate event=] at |appHistory| given <var ignore>url</var>, with <i>[=fire a navigate event/isPush=]</i> set to false, <i>[=fire a navigate event/isSameDocument=]</i> set to |isSameDocument|, <i>[=fire a navigate event/userInvolvement=]</i> set to |userInvolvement|, <i>[=fire a navigate event/isHistoryTraversal=]</i> set to true,  and <i>[=fire a navigate event/hashChange=]</i> set to |hashChange|.
+    1. Let |continue| be the result of [=firing a navigate event=] at |appHistory| given <var ignore>url</var>, with <i>[=fire a navigate event/isPush=]</i> set to false, <i>[=fire a navigate event/isSameDocument=]</i> set to |isSameDocument|, <i>[=fire a navigate event/userInvolvement=]</i> set to |userInvolvement|, and <i>[=fire a navigate event/isHistoryTraversal=]</i> set to true.
     1. If |continue| is false, abort these steps.
 </div>

--- a/spec.bs
+++ b/spec.bs
@@ -16,6 +16,19 @@ Complain About: accidental-2119 yes, missing-example-ids yes
 Indent: 2
 Default Biblio Status: current
 Markup Shorthands: markdown yes
+Assume Explicit For: yes
+</pre>
+
+<pre class="link-defaults">
+spec: html; type: element; text: a
+</pre>
+<pre class="anchors">
+spec: html; type: dfn; urlPrefix: https://html.spec.whatwg.org/multipage/
+  text: serialized state; url: history.html#serialized-state
+  for: URL and history update steps
+    text: serializedData; url: history.html#uhus-serializeddata
+    text: title; url: history.html#uhus-title
+    text: isPush; url: history.html#uhus-ispush
 </pre>
 
 <style>
@@ -28,8 +41,210 @@ Markup Shorthands: markdown yes
   padding: 4px 10px;
   z-index: 4;
 }
+
+/* domintro from https://resources.whatwg.org/standard.css */
+.domintro {
+  position: relative;
+  color: green;
+  background: #DDFFDD;
+  margin: 2.5em 0 2em 0;
+  padding: 1.5em 1em 0.5em 2em;
+}
+
+.domintro dt, .domintro dt * {
+  color: black;
+  font-size: inherit;
+}
+.domintro dd {
+  margin: 0.5em 0 1em 2em; padding: 0;
+}
+.domintro dd p {
+  margin: 0.5em 0;
+}
+.domintro::before {
+  content: 'For web developers (non-normative)';
+  background: green;
+  color: white;
+  padding: 0.15em 0.25em;
+  font-style: normal;
+  position: absolute;
+  top: -0.8em;
+  left: -0.8em;
+}
 </style>
 
 <script src="https://resources.whatwg.org/file-issue.js" async></script>
 
-TODO write some spec text!
+<h2 id="global">The {{AppHistory}} interface</h2>
+
+<xmp class="idl">
+partial interface Window {
+  readonly attribute AppHistory appHistory;
+};
+</xmp>
+
+Each {{Window}} object has an associated <dfn for="Window">app history</dfn>, which is a new {{AppHistory}} instance created alongside the {{Window}}.
+
+The <dfn attribute for="Window">appHistory</dfn> getter steps are to return [=this=]'s [=Window/app history=].
+
+<xmp class="idl">
+[Exposed=Window]
+interface AppHistory : EventTarget {
+  attribute EventHandler onnavigate;
+  attribute EventHandler onnavigatesuccess;
+  attribute EventHandler onnavigateerror;
+};
+</xmp>
+
+The following are the [=event handlers=] (and their corresponding [=event handler event types=]) that must be supported, as [=event handler IDL attributes=], by objects implementing the {{AppHistory}} interface:
+
+<table>
+  <thead>
+    <th>[=Event handler=]
+    <th>[=Event handler event type=]
+  <tbody>
+    <tr>
+      <td><dfn attribute for="AppHistory">onnavigate</dfn>
+      <td><dfn event for="AppHistory">navigate</dfn>
+    <tr>
+      <td><dfn attribute for="AppHistory">onnavigatesuccess</dfn>
+      <td><dfn event for="AppHistory">navigatesuccess</dfn>
+    <tr>
+      <td><dfn attribute for="AppHistory">onnavigateerror</dfn>
+      <td><dfn event for="AppHistory">navigateerror</dfn>
+</table>
+
+<h2 id="navigate-event">The {{AppHistory/navigate}} event</h2>
+
+<xmp class="idl">
+[Exposed=Window]
+interface AppHistoryNavigateEvent : Event {
+  constructor(DOMString type, optional AppHistoryNavigateEventInit eventInit = {});
+
+  readonly attribute boolean canRespond;
+  readonly attribute boolean userInitiated;
+  readonly attribute boolean hashChange;
+//  readonly attribute AppHistoryEntry destination;
+  readonly attribute AbortSignal signal;
+  readonly attribute FormData? formData;
+  readonly attribute any info;
+
+  undefined respondWith(Promise<undefined> newNavigationAction);
+};
+
+dictionary AppHistoryNavigateEventInit : EventInit {
+  boolean canRespond = false;
+  boolean userInitiated = false;
+  boolean hashChange = false;
+//  required AppHistoryEntry destination;
+  required AbortSignal signal;
+  FormData? formData = null;
+  any info = null;
+};
+</xmp>
+
+<dl class="domintro non-normative">
+  <dt><code>event . {{AppHistoryNavigateEvent/canRespond}}</code>
+  <dd>
+    <p>True if {{AppHistoryNavigateEvent/respondWith()}} can be called to convert this navigation into a single-page navigation; false otherwise.
+
+    <p>Generally speaking, this will be true whenever the destination URL is [=rewritable=] relative to the page's current URL, except for cross-document back/forward navigations, where it will always be false.
+  </dd>
+
+  <dt><code>event . {{AppHistoryNavigateEvent/userInitiated}}</code>
+  <dd>
+    <p>True if this navigation was due to a user clicking on an <{a}> element, submitting a <{form}> element, or using the browser UI to navigate; false otherwise.
+  </dd>
+
+  <dt><code>event . {{AppHistoryNavigateEvent/hashChange}}</code>
+  <dd>
+    <p>True if this navigation is a <a spec="HTML" lt="navigate to a fragment">fragment navigation</a>; false otherwise.
+  </dd>
+
+  <dt><code>event . {{AppHistoryNavigateEvent/signal}}</code>
+  <dd>
+    <p>An {{AbortSignal}} which will become aborted if the navigation gets canceled, e.g. by the user pressing their browser's "Stop" button, or another higher-priority navigation interrupting this one.
+
+    <p>The expected pattern is for developers to pass this along to any async operations, such as {{WindowOrWorkerGlobalScope/fetch()}}, which they perform as part of handling this navigation.
+  </dd>
+
+  <dt><code>event . {{AppHistoryNavigateEvent/formData}}</code>
+  <dd>
+    <p>The {{FormData}} representing the submitted form entries for this navigation, if this navigation was a <a spec="HTML" lt="submit">form submission</a>; null otherwise.
+  </dd>
+
+  <dt><code>event . {{AppHistoryNavigateEvent/info}}</code>
+  <dd>
+    <p>An arbitrary JavaScript value passed via other app history APIs that initiated this navigation, or null if the navigation was initiated by the user or via a non-app history API.
+  </dd>
+
+  <dt><code>event . {{AppHistoryNavigateEvent/respondWith()|respondWith}}( |newNavigationAction| )</code>
+  <dd>
+    <p>Synchronously converts this navigation into a same-document navigation to the destination URL.
+
+    <p>The given |newNavigationAction| promise is used to signal the duration, and success or failure, of the navigation. After it settles, the browser signals to the user (e.g. via a loading spinner UI, or assistive technology) that the navigation is finished. Additionally, it fires {{AppHistory/navigatesuccess}} or {{AppHistory/navigateerror}} events as appropriate, which other parts of the web application can respond to.
+
+    <p>This method will throw a "{{SecurityError}}" {{DOMException}} if {{AppHistoryNavigateEvent/canRespond}} is false, or if {{Event/isTrusted}} is false. It will throw an "{{InvalidStateError}}" {{DOMException}} if not called synchronously, during event dispatch.
+  </dd>
+</dl>
+
+The <dfn attribute for="AppHistoryNavigateEvent">canRespond</dfn>, <dfn attribute for="AppHistoryNavigateEvent">userInitiated</dfn>, <dfn attribute for="AppHistoryNavigateEvent">hashChange</dfn>, <dfn attribute for="AppHistoryNavigateEvent">signal</dfn>, <dfn attribute for="AppHistoryNavigateEvent">formData</dfn>, and <dfn attribute for="AppHistoryNavigateEvent">info</dfn> getter steps are to return the value that the corresponding attribute was initialized to.
+
+An {{AppHistoryNavigateEvent}} has an associated [=URL=] <dfn for="AppHistoryNavigateEvent">destination URL</dfn>, an associated boolean <dfn for="AppHistoryNavigateEvent">is push</dfn>, an associated [=serialized state=]-or-null <dfn for="AppHistoryNavigateEvent">classic history API serialized data</dfn>, and an optional string-or-null <dfn for="AppHistoryNavigateEvent">classic history API title</dfn>. All of these are set when the event is [=fire a navigate event|fired=].
+
+<div algorithm>
+  The <dfn method for="AppHistoryNavigateEvent">respondWith(|newNavigationAction|)</dfn> method steps are:
+
+  1. If [=this=]'s {{Event/isTrusted}} attribute was initialized to false, then throw a "{{SecurityError}}" {{DOMException}}.
+  1. If [=this=]'s {{AppHistoryNavigateEvent/canRespond}} attribute was initialized to false, then throw a "{{SecurityError}}" {{DOMException}}.
+  1. If [=this=]'s [=Event/dispatch flag=] is unset, then throw an "{{InvalidStateError}}" {{DOMException}}.
+  1. If [=this=]'s [=Event/canceled flag=] is unset, then throw an "{{InvalidStateError}}" {{DOMException}}.
+  1. Set [=this=]'s [=Event/canceled flag=].
+  1. Run the <a spec="HTML">URL and history update steps</a> given [=this=]'s [=relevant global object=]'s [=associated document=] and [=this=]'s [=AppHistoryNavigateEvent/destination URL=], with <i>[=URL and history update steps/serializedData=]</i> set to [=this=]'s [=AppHistoryNavigateEvent/classic history API serialized data=], <i>[=URL and history update steps/title=]</i> set to [=this=]'s [=AppHistoryNavigateEvent/classic history API title=], and <i>[=URL and history update steps/isPush=]</i> set to [=this=]'s [=AppHistoryNavigateEvent/is push=].
+  1. Let |appHistory| be [=this=]'s [=relevant global object=]'s [=Window/app history=].
+  1. [=promise/React=] to |newNavigationAction| with the following fulfillment steps:
+      1. [=Fire an event=] named {{AppHistory/navigatesuccess}} at |appHistory|.
+    and the following rejection steps given reason |rejectionReason|:
+      1. [=Fire an event=] named {{AppHistory/navigateerror}} at |appHistory| using {{ErrorEvent}}, with {{ErrorEvent/error}} initialized to |rejectionReason|, and {{ErrorEvent/message}}, {{ErrorEvent/filename}}, {{ErrorEvent/lineno}}, and {{ErrorEvent/colno}} initialized to appropriate values that can be extracted from |rejectionReason| in the same underspecified way the user agent typically does for the <a spec="HTML">report an exception</a> algorithm.
+</div>
+
+<hr>
+
+<div algorithm>
+  To <dfn>fire a `navigate` event</dfn> at an {{AppHistory}} |appHistory| given a [=URL=] |destinationURL|, a boolean |isPush|, a boolean |isCrossDocument|, a boolean |isBackForward|, a boolean |isBrowserUI|, a boolean |isUserInitiated|, a boolean |isFragmentNavigation|, an optional value |navigateInfo| (default null), an optional [=list=] of [=FormData/entries=] |formDataEntryList|, an optional [=serialized state=]-or-null |classicHistoryAPISerializedData| (default null), and an optional string-or-null |classicHistoryAPITitle| (default null):
+
+  1. Let |event| be the result of [=creating an event=] given {{AppHistoryNavigateEvent}}, in the [=relevant Realm=] of |appHistory|.
+  1. Set |event|'s [=AppHistoryNavigateEvent/destination URL=] to |destinationURL|.
+  1. Set |event|'s [=AppHistoryNavigateEvent/is push=] to |isPush|.
+  1. Set |event|'s [=AppHistoryNavigateEvent/classic history API serialized data=] to |classicHistoryAPISerializedData|.
+  1. Set |event|'s [=AppHistoryNavigateEvent/classic history API title=] to |classicHistoryAPITitle|.
+  1. Initialize |event|'s {{Event/type}} to {{AppHistory/navigate}}.
+  1. Initialize |event|'s {{AppHistoryNavigateEvent/userInitiated}} to |isUserInitiated|.
+  1. Initialize |event|'s {{AppHistoryNavigateEvent/hashChange}} to |isFragmentNavigation|.
+  1. Initialize |event|'s {{AppHistoryNavigateEvent/signal}} to a [=new=] {{AbortSignal}} created in the [=relevant Realm=] of |appHistory|.
+  1. Initialize |event|'s {{AppHistoryNavigateEvent/info}} to |navigateInfo|.
+  1. Let |currentURL| be |appHistory|'s [=relevant global object=]'s [=associated document=]'s [=Document/URL=].
+  1. If |destinationURL| is [=rewritable=] relative to |currentURL|, and either |isCrossDocument| is false or |isBackForward| is false, then initialize |event|'s {{AppHistoryNavigateEvent/canRespond}} to true. Otherwise, initialize it to false.
+  1. If either |isBrowserUI| is false or |isBackForward| is false, then initialize |event|'s {{Event/cancelable}} to true.
+  1. If |formDataEntryList| is given, then initialize |event|'s {{AppHistoryNavigateEvent/formData}} to a [=new=] {{FormData}} created in the [=relevant Realm=] of |appHistory|, associated to |formDataEntryList|. Otherwise, initialize it to null.
+  1. Return the result of [=dispatching=] |event| at |appHistory|.
+</div>
+
+TODO should canRespond become false after calling respondWith? Should it incorporate the other error conditions?
+
+<!-- Remember to modify pushState()/replaceState() to use this, when we eventually move to the HTML Standard. -->
+A [=URL=] is <dfn>rewritable</dfn> relative to another [=URL=] if they differ in only the [=url/path=], [=url/query=], or [=url/fragment=] components.
+
+<div class="example" id="example-rewritable-url">
+  `https://example.com/foo?bar#baz` is rewritable relative to `https://example.com/qux`.
+
+  However, the concept is not the same as the two URLs' [=url/origins=] being [=same origin|the same=]: `https://user:password@example.com/qux` is not rewritable relative to `https://example.com/qux`.
+
+  Similarly, `about:blank` or `blob:` URLs are not rewritable relative to `https:` URLs, despite there being cases where a `https`:-[=Document/URL=] {{Document}} is [=same origin=] with an `about:blank` or `blob:`-derived {{Document}}.
+</div>
+
+<h2 id="navigate-patches">Patches to fire the {{AppHistory/navigate}} event</h2>
+
+The following section details monkeypatches to [[!HTML]] that cause the {{AppHistory/navigate}} event to be fired appropriately, and for canceling the event to cancel the navigation.
+
+TODO!

--- a/spec.bs
+++ b/spec.bs
@@ -303,12 +303,6 @@ Introduce (right before the definition of the <a spec="HTML">navigate</a> algori
 : "<dfn for="user navigation involvement"><code>none</code></dfn>"
 :: The navigation was not initiated by the user
 
-Modify the <a spec="HTML">traverse the history by a delta</a> argument to take an optional named argument <dfn for="traverse the history by a delta"><var ignore>userInvolvement</var></dfn> (default "<code>[=user navigation involvement/none=]</code>"). Then, update the paragraph talking about user-initiated navigation as follows:
-
-<blockquote>
-  When the user navigates through a [=browsing context=], e.g. using a browser's back and forward buttons, the user agent must <a spec="HTML">traverse the history by a delta</a> with a delta equivalent to the action specified by the user<del> and</del><ins>,</ins> the browsing context being operated on<ins>, and <i>[=traverse the history by a delta/userInvolvement=]</i> set to "<code>[=user navigation involvement/browser UI=]</code>"</ins>.
-</blockquote>
-
 Modify the <a spec="HTML">navigate</a> algorithm to take an optional named argument <dfn for="navigate"><var ignore>userInvolvement</var></dfn> (default "<code>[=user navigation involvement/none=]</code>"). Then, update the paragraph talking about browser-UI initiated navigation as follows:
 
 <blockquote>
@@ -318,6 +312,14 @@ Modify the <a spec="HTML">navigate</a> algorithm to take an optional named argum
 <p class="note">This infrastructure partially solves <a href="https://github.com/whatwg/html/issues/5381">whatwg/html#5381</a>, and it'd be ideal to update the \`<a http-header><code>Sec-Fetch-Dest</code></a>\` spec at the same time.</p>
 
 Modify the <a spec="HTML">navigate to a fragment</a> algorithm to take a new <var ignore>userInvolvement</var> argument. Then, update the call to it from <a spec="HTML">navigate</a> to set <i>[=navigate/userInvolvement=]</i> to this <var ignore>userInvolvement</var> value.
+
+Modify the <a spec="HTML">traverse the history by a delta</a> argument to take an optional named argument <dfn for="traverse the history by a delta"><var ignore>userInvolvement</var></dfn> (default "<code>[=user navigation involvement/none=]</code>"). Then, update the paragraph talking about user-initiated navigation as follows:
+
+<blockquote>
+  When the user navigates through a [=browsing context=], e.g. using a browser's back and forward buttons, the user agent must <a spec="HTML">traverse the history by a delta</a> with a delta equivalent to the action specified by the user<del> and</del><ins>,</ins> the browsing context being operated on<ins>, and <i>[=traverse the history by a delta/userInvolvement=]</i> set to "<code>[=user navigation involvement/browser UI=]</code>"</ins>.
+</blockquote>
+
+<hr>
 
 Modify the <a spec="HTML">follows a hyperlink</a> algorithm to take a new <var ignore>userInvolvement</var> argument. Then, update the call to it from <a spec="HTML">navigate</a> to set <i>[=navigate/userInvolvement=]</i> to this <var ignore>userInvolvement</var> value.
 
@@ -340,6 +342,8 @@ Modify the <a spec="HTML">follows a hyperlink</a> algorithm to take a new <var i
 Expand the section on "<a href="https://html.spec.whatwg.org/multipage/semantics.html#providing-users-with-a-means-to-follow-hyperlinks-created-using-the-link-element">Providing users with a means to follow hyperlinks created using the `link` element</a>" by adding the following sentence:
 
 <blockquote><ins>Such invocations of <a spec="HTML" lt="follows a hyperlink">follow the hyperlink</a> algorithm must set the <i>[=navigate/userInvolvement=]</i> argument to "<code>[=user navigation involvement/browser UI=]</code>".</ins></blockquote>
+
+<hr>
 
 TODO form submission user-initiated.
 

--- a/spec.bs
+++ b/spec.bs
@@ -270,7 +270,7 @@ A [=URL=] is <dfn>rewritable</dfn> relative to another [=URL=] if they differ in
 
 <h2 id="navigate-patches">Patches to fire the {{AppHistory/navigate}} event</h2>
 
-The following section details monkeypatches to [[!HTML]] that cause the {{AppHistory/navigate}} event to be fired appropriately, and for canceling the event to cancel the navigation. The first couple of sections detail slight tweaks to existing algorithms to pass through useful information. Then, [[#navigate-algorithm-patches]] contains the actual firing of the event.
+The following section details monkeypatches to [[!HTML]] that cause the {{AppHistory/navigate}} event to be fired appropriately, and for canceling the event to cancel the navigation. The first few sections detail slight tweaks to existing algorithms to pass through useful information into the navigation and history traversal algorithms. Then, [[#navigate-algorithm-patches]] contains the actual firing of the event.
 
 <h3 id="form-patches">Form submission patches</h3>
 
@@ -292,9 +292,9 @@ To properly thread the form entry list from its creation through to {{AppHistory
   Modify the <a spec="HTML">submit as entity body</a> algorithm to pass <var ignore>entry list</var> along to <a spec="HTML">plan to navigate</a> as a second argument.
 </div>
 
-<h3 id="user-initiated-patches">User-initiated patches</h3>
+<h3 id="user-initiated-patches">Browser UI/user-initiated patches</h3>
 
-To more rigorously specify when a navigation is user-initiated, both for the purposes of the {{AppHistoryNavigateEvent}}'s {{AppHistoryNavigateEvent/userInitiated}} property and for prohibiting interception of certain types of browser-UI-initiated navigations, we need the following modifications:
+To more rigorously specify when a navigation is initiated from browser UI or by the user interacting with <{a}>, <{area}>, and <{form}> elements, both for the purposes of the {{AppHistoryNavigateEvent}}'s {{AppHistoryNavigateEvent/userInitiated}} property and for prohibiting interception of certain types of browser-UI-initiated navigations, we need the following modifications:
 
 Modify the <a spec="HTML">traverse the history by a delta</a> argument to take an optional named argument <dfn for="traverse the history by a delta"><var ignore>fromBrowserUI</var></dfn> (default false). Then, update the paragraph talking about user-initiated navigation as follows:
 
@@ -302,15 +302,39 @@ Modify the <a spec="HTML">traverse the history by a delta</a> argument to take a
   When the user navigates through a [=browsing context=], e.g. using a browser's back and forward buttons, the user agent must <a spec="HTML">traverse the history by a delta</a> with a delta equivalent to the action specified by the user<del> and</del><ins>,</ins> the browsing context being operated on<ins>, and <i>[=traverse the history by a delta/fromBrowserUI=]</i> set to true</ins>.
 </blockquote>
 
-Modify the <a spec="HTML">navigate</a> algorithm to take an optional named argument <dfn for="navigate"><var ignore>fromBrowserUI</var></dfn> (default false). Then, update the paragraph talking about user-initiated navigation as follows:
+Modify the <a spec="HTML">navigate</a> algorithm to take two optional named arguments <dfn for="navigate"><var ignore>fromBrowserUI</var></dfn> (default false) and <dfn for="navigate"><var ignore>isUserInitiated</var></dfn> (default false). Then, update the paragraph talking about browser-UI initiated navigation as follows:
 
 <blockquote>
-  A user agent may provide various ways for the user to explicitly cause a browsing context to navigate, in addition to those defined in this specification.<ins> Such cases must set the <i>[=navigate/fromBrowserUI=]</i> argument to true.
+  A user agent may provide various ways for the user to explicitly cause a browsing context to <a spec="HTML">navigate</a>, in addition to those defined in this specification.<ins> Such cases must set the <i>[=navigate/fromBrowserUI=]</i> and <i>[=navigate/isUserInitiated=]</i> arguments to true.</ins>
 </blockquote>
 
-<p class="note">This partially solves <a href="https://github.com/whatwg/html/issues/5381">whatwg/html#5381</a>, and it'd be ideal to update the \`<a http-header><code>Sec-Fetch-Dest</code></a>\` spec at the same time.</p>
+<p class="note">The <i>[=navigate/fromBrowserUI=]</i> argument partially solves <a href="https://github.com/whatwg/html/issues/5381">whatwg/html#5381</a>, and it'd be ideal to update the \`<a http-header><code>Sec-Fetch-Dest</code></a>\` spec at the same time.</p>
 
-Modify the <a spec="HTML">navigate to a fragment</a> algorithm to take a new <var ignore>fromBrowserUI</var> argument as its last argument. Then, update the call to it from <a spec="HTML">navigate</a> to pass along its own <var ignore>fromBrowserUI</var> value.
+Modify the <a spec="HTML">navigate to a fragment</a> algorithm to take new <var ignore>fromBrowserUI</var> and <var ignore>isUserInitiated</var> arguments as its last arguments. Then, update the call to it from <a spec="HTML">navigate</a> to pass along its own <var ignore>fromBrowserUI</var> and <var ignore>isUserInitiated</var> values.
+
+Modify the <a spec="HTML">follows a hyperlink</a> algorithm to take optional named arguments <dfn for="follows a hyperlink"><var ignore>isUserInitiated</var></dfn> (default false) and <dfn for="follows a hyperlink"><var ignore>fromBrowserUI</var></dfn> (default false). Then in the final step, pass these along as the value of the <i>[=navigate/isUserInitiated=]</i> and <i>[=navigate/fromBrowserUI=]</i> arguments to the <a spec="HTML">navigate</a> call.
+
+<div algorithm="area activation behavior">
+  Modify the [=EventTarget/activation behavior=] of <{area}> elements by introducing the |event| argument and replacing the <a spec="HTML" lt="follows a hyperlink">follow the hyperlink</a> step with the following:
+
+  1. Otherwise:
+    1. Let |isUserInitiated| be true if |event|'s {{Event/isTrusted}} attribute is initialized to true; otherwise, false.
+    1. <a spec="HTML" lt="follows a hyperlink">Follow the hyperlink</a> created by |element| with <i>[=follows a hyperlink/isUserInitiated=]</i> set to |isUserInitiated|.
+</div>
+
+<div algorithm="area activation behavior">
+  Modify the [=EventTarget/activation behavior=] of <{a}> elements by replacing its <a spec="HTML" lt="follows a hyperlink">follow the hyperlink</a> step with the following:
+
+  1. Otherwise:
+    1. Let |isUserInitiated| be true if |event|'s {{Event/isTrusted}} attribute is initialized to true; otherwise, false.
+    1. <a spec="HTML" lt="follows a hyperlink">Follow the hyperlink</a> created by |element| with <i>[=follows a hyperlink/isUserInitiated=]</i> set to |isUserInitiated|.
+</div>
+
+Expand the section on "<a href="https://html.spec.whatwg.org/multipage/semantics.html#providing-users-with-a-means-to-follow-hyperlinks-created-using-the-link-element">Providing users with a means to follow hyperlinks created using the `link` element</a>" by adding the following sentence:
+
+<blockquote><ins>Such invocations of <a spec="HTML" lt="follows a hyperlink">follow the hyperlink</a> algorithm must set the <i>[=navigate/fromBrowserUI=]</i> argument to true.</ins></blockquote>
+
+TODO form submission user-initiated.
 
 <h3 id="navigate-algorithm-patches">Navigation algorithm updates</h3>
 
@@ -329,7 +353,7 @@ With the above infrastructure in place, we can actually fire and handle the {{Ap
 
   1. Let |appHistory| be the <a spec="HTML">current entry</a>'s <a spec="HTML" for="session history entry">document</a>'s [=relevant global object=]'s [=Window/app history=].
   1. Let |isPush| be true if <var ignore>historyHandling</var> is "<a spec="HTML" for="history handling behavior">`default`</a>"; otherwise, false.
-  1. Let |continue| be the result of [=firing a navigate event=] at |appHistory| given <var ignore>url</var>, with <i>[=fire a navigate event/isPush=]</i> set to |isPush|, <i>[=fire a navigate event/isCrossDocument=]</i> set to false, <i>[=fire a navigate event/isUserInitiated=]</i> set to ???TODO, and <i>[=fire a navigate event/isFragmentNavigation=]</i> set to true.
+  1. Let |continue| be the result of [=firing a navigate event=] at |appHistory| given <var ignore>url</var>, with <i>[=fire a navigate event/isPush=]</i> set to |isPush|, <i>[=fire a navigate event/isCrossDocument=]</i> set to false, <i>[=fire a navigate event/isUserInitiated=]</i> set to <var ignore>isUserInitiated</var>, and <i>[=fire a navigate event/isFragmentNavigation=]</i> set to true.
   1. If |continue| is false, return.
 </div>
 
@@ -339,7 +363,7 @@ With the above infrastructure in place, we can actually fire and handle the {{Ap
   1. If <var ignore>historyHandling</var> is not "<a for="history handling behavior">`entry update`</a>", and <var ignore>fromBrowserUI</var> is false, then:
     1. Let |appHistory| be <var ignore>browsingContext</var>'s [=browsing context/active window=]'s [=Window/app history=].
     1. Let |isPush| be true if <var ignore>historyHandling</var> is "<a for="history handling behavior">`default`</a>"; otherwise, false.
-    1. Let |continue| be the result of [=firing a navigate event=] at |appHistory| given <var ignore>url</var>, with <i>[=fire a navigate event/isPush=]</i> set to |isPush|, <i>[=fire a navigate event/isUserInitiated=]</i> set to ???TODO, <i>[=fire a navigate event/isCrossDocument=]</i> set to true, and <i>[=fire a navigate event/formDataEntryList=]</i> set to <var ignore>entryList</var>.
+    1. Let |continue| be the result of [=firing a navigate event=] at |appHistory| given <var ignore>url</var>, with <i>[=fire a navigate event/isPush=]</i> set to |isPush|, <i>[=fire a navigate event/isUserInitiated=]</i> set to <var ignore>isUserInitiated</var>, <i>[=fire a navigate event/isCrossDocument=]</i> set to true, and <i>[=fire a navigate event/formDataEntryList=]</i> set to <var ignore>entryList</var>.
     1. If |continue| is false, return.
 
     <p class="note">[=User agent=]-specific mechanisms that cause <a spec="HTML" lt="navigate to a fragment">fragment navigations</a> <em>do</em> fire the {{AppHistory/navigate}} event; those are handled as part of the <a spec="HTML">navigate to a fragment</a> algorithm, which does not have this condition.

--- a/spec.bs
+++ b/spec.bs
@@ -236,7 +236,7 @@ An {{AppHistoryNavigateEvent}} has an associated [=URL=] <dfn for="AppHistoryNav
 <hr>
 
 <div algorithm="fire a navigate event">
-  To <dfn>fire a `navigate` event</dfn> at an {{AppHistory}} |appHistory| given a [=URL=] |destinationURL|, a boolean <dfn for="fire a navigate event">|isPush|</dfn>, a boolean <dfn for="fire a navigate event">|isCrossDocument|</dfn>, a boolean <dfn for="fire a navigate event">|isBackForward|</dfn> (default false), a boolean <dfn for="fire a navigate event">|isBrowserUI|</dfn> (default false), a boolean <dfn for="fire a navigate event">|isUserInitiated|</dfn> (default false), a boolean <dfn for="fire a navigate event">|isFragmentNavigation|</dfn> (default false), an optional value |navigateInfo| (default null), an optional [=list=] of [=FormData/entries=] or null <dfn for="fire a navigate event">|formDataEntryList|</dfn> (default null), an optional [=serialized state=]-or-null <dfn for="fire a navigate event">|classicHistoryAPISerializedData|</dfn> (default null), and an optional string-or-null <dfn for="fire a navigate event">|classicHistoryAPITitle|</dfn> (default null):
+  To <dfn>fire a `navigate` event</dfn> at an {{AppHistory}} |appHistory| given a [=URL=] |destinationURL|, an optional boolean <dfn for="fire a navigate event">|isPush|</dfn>, an optional boolean <dfn for="fire a navigate event">|isCrossDocument|</dfn>, an optional boolean <dfn for="fire a navigate event">|isBackForward|</dfn> (default false), an optional [=user navigation involvement=] <dfn for="fire a navigate event">|userInvolvement|</dfn> (default "<code>[=user navigation involvement/none=]</code>"), an optional boolean <dfn for="fire a navigate event">|isFragmentNavigation|</dfn> (default false), an optional value |navigateInfo| (default null), an optional [=list=] of [=FormData/entries=] or null <dfn for="fire a navigate event">|formDataEntryList|</dfn> (default null), an optional [=serialized state=]-or-null <dfn for="fire a navigate event">|classicHistoryAPISerializedData|</dfn> (default null), and an optional string-or-null <dfn for="fire a navigate event">|classicHistoryAPITitle|</dfn> (default null):
 
   1. Let |event| be the result of [=creating an event=] given {{AppHistoryNavigateEvent}}, in the [=relevant Realm=] of |appHistory|.
   1. Set |event|'s [=AppHistoryNavigateEvent/destination URL=] to |destinationURL|.
@@ -244,13 +244,13 @@ An {{AppHistoryNavigateEvent}} has an associated [=URL=] <dfn for="AppHistoryNav
   1. Set |event|'s [=AppHistoryNavigateEvent/classic history API serialized data=] to |classicHistoryAPISerializedData|.
   1. Set |event|'s [=AppHistoryNavigateEvent/classic history API title=] to |classicHistoryAPITitle|.
   1. Initialize |event|'s {{Event/type}} to {{AppHistory/navigate}}.
-  1. Initialize |event|'s {{AppHistoryNavigateEvent/userInitiated}} to |isUserInitiated|.
   1. Initialize |event|'s {{AppHistoryNavigateEvent/hashChange}} to |isFragmentNavigation|.
   1. Initialize |event|'s {{AppHistoryNavigateEvent/signal}} to a [=new=] {{AbortSignal}} created in the [=relevant Realm=] of |appHistory|.
   1. Initialize |event|'s {{AppHistoryNavigateEvent/info}} to |navigateInfo|.
   1. Let |currentURL| be |appHistory|'s [=relevant global object=]'s [=associated document=]'s [=Document/URL=].
   1. If |destinationURL| is [=rewritable=] relative to |currentURL|, and either |isCrossDocument| is false or |isBackForward| is false, then initialize |event|'s {{AppHistoryNavigateEvent/canRespond}} to true. Otherwise, initialize it to false.
-  1. If either |isBrowserUI| is false or |isBackForward| is false, then initialize |event|'s {{Event/cancelable}} to true.
+  1. If either |userInvolvement| is not "<code>[=user navigation involvement/browser UI=]</code>" or |isBackForward| is false, then initialize |event|'s {{Event/cancelable}} to true.
+  1. If |userInvolvement| is "<code>[=user navigation involvement/none=]</code>", then initialize |event|'s {{AppHistoryNavigateEvent/userInitiated}} to false. Otherwise, initialize it to true.
   1. If |formDataEntryList| is not null, then initialize |event|'s {{AppHistoryNavigateEvent/formData}} to a [=new=] {{FormData}} created in the [=relevant Realm=] of |appHistory|, associated to |formDataEntryList|. Otherwise, initialize it to null.
   1. Return the result of [=dispatching=] |event| at |appHistory|.
 </div>
@@ -296,43 +296,52 @@ To properly thread the form entry list from its creation through to {{AppHistory
 
 To more rigorously specify when a navigation is initiated from browser UI or by the user interacting with <{a}>, <{area}>, and <{form}> elements, both for the purposes of the {{AppHistoryNavigateEvent}}'s {{AppHistoryNavigateEvent/userInitiated}} property and for prohibiting interception of certain types of browser-UI-initiated navigations, we need the following modifications:
 
-Modify the <a spec="HTML">traverse the history by a delta</a> argument to take an optional named argument <dfn for="traverse the history by a delta"><var ignore>fromBrowserUI</var></dfn> (default false). Then, update the paragraph talking about user-initiated navigation as follows:
+Introduce (right before the definition of the <a spec="HTML">navigate</a> algorithm) the concept of a <dfn>user navigation involvement</dfn>, which is one of the following:
+
+: "<dfn for="user navigation involvement"><code>browser UI</code></dfn>"
+:: The navigation was initiated by the user via browser UI mechanisms
+: "<dfn for="user navigation involvement"><code>activation</code></dfn>"
+:: The navigation was initiated by the user via the [=EventTarget/activation behavior=] of an element
+: "<dfn for="user navigation involvement"><code>none</code></dfn>"
+:: The navigation was not initiated by the user
+
+Modify the <a spec="HTML">traverse the history by a delta</a> argument to take an optional named argument <dfn for="traverse the history by a delta"><var ignore>userInvolvement</var></dfn> (default "<code>[=user navigation involvement/none=]</code>"). Then, update the paragraph talking about user-initiated navigation as follows:
 
 <blockquote>
-  When the user navigates through a [=browsing context=], e.g. using a browser's back and forward buttons, the user agent must <a spec="HTML">traverse the history by a delta</a> with a delta equivalent to the action specified by the user<del> and</del><ins>,</ins> the browsing context being operated on<ins>, and <i>[=traverse the history by a delta/fromBrowserUI=]</i> set to true</ins>.
+  When the user navigates through a [=browsing context=], e.g. using a browser's back and forward buttons, the user agent must <a spec="HTML">traverse the history by a delta</a> with a delta equivalent to the action specified by the user<del> and</del><ins>,</ins> the browsing context being operated on<ins>, and <i>[=traverse the history by a delta/userInvolvement=]</i> set to "<code>[=user navigation involvement/browser UI=]</code>"</ins>.
 </blockquote>
 
-Modify the <a spec="HTML">navigate</a> algorithm to take two optional named arguments <dfn for="navigate"><var ignore>fromBrowserUI</var></dfn> (default false) and <dfn for="navigate"><var ignore>isUserInitiated</var></dfn> (default false). Then, update the paragraph talking about browser-UI initiated navigation as follows:
+Modify the <a spec="HTML">navigate</a> algorithm to take an optional named argument <dfn for="navigate"><var ignore>userInvolvement</var></dfn> (default "<code>[=user navigation involvement/none=]</code>"). Then, update the paragraph talking about browser-UI initiated navigation as follows:
 
 <blockquote>
-  A user agent may provide various ways for the user to explicitly cause a browsing context to <a spec="HTML">navigate</a>, in addition to those defined in this specification.<ins> Such cases must set the <i>[=navigate/fromBrowserUI=]</i> and <i>[=navigate/isUserInitiated=]</i> arguments to true.</ins>
+  A user agent may provide various ways for the user to explicitly cause a browsing context to <a spec="HTML">navigate</a>, in addition to those defined in this specification.<ins> Such cases must set the <i>[=navigate/userInvolvement=]</i> argument to "<code>[=user navigation involvement/browser UI=]</code>".</ins>
 </blockquote>
 
-<p class="note">The <i>[=navigate/fromBrowserUI=]</i> argument partially solves <a href="https://github.com/whatwg/html/issues/5381">whatwg/html#5381</a>, and it'd be ideal to update the \`<a http-header><code>Sec-Fetch-Dest</code></a>\` spec at the same time.</p>
+<p class="note">This infrastructure partially solves <a href="https://github.com/whatwg/html/issues/5381">whatwg/html#5381</a>, and it'd be ideal to update the \`<a http-header><code>Sec-Fetch-Dest</code></a>\` spec at the same time.</p>
 
-Modify the <a spec="HTML">navigate to a fragment</a> algorithm to take new <var ignore>fromBrowserUI</var> and <var ignore>isUserInitiated</var> arguments as its last arguments. Then, update the call to it from <a spec="HTML">navigate</a> to pass along its own <var ignore>fromBrowserUI</var> and <var ignore>isUserInitiated</var> values.
+Modify the <a spec="HTML">navigate to a fragment</a> algorithm to take a new <var ignore>userInvolvement</var> argument. Then, update the call to it from <a spec="HTML">navigate</a> to set <i>[=navigate/userInvolvement=]</i> to this <var ignore>userInvolvement</var> value.
 
-Modify the <a spec="HTML">follows a hyperlink</a> algorithm to take optional named arguments <dfn for="follows a hyperlink"><var ignore>isUserInitiated</var></dfn> (default false) and <dfn for="follows a hyperlink"><var ignore>fromBrowserUI</var></dfn> (default false). Then in the final step, pass these along as the value of the <i>[=navigate/isUserInitiated=]</i> and <i>[=navigate/fromBrowserUI=]</i> arguments to the <a spec="HTML">navigate</a> call.
+Modify the <a spec="HTML">follows a hyperlink</a> algorithm to take a new <var ignore>userInvolvement</var> argument. Then, update the call to it from <a spec="HTML">navigate</a> to set <i>[=navigate/userInvolvement=]</i> to this <var ignore>userInvolvement</var> value.
 
 <div algorithm="area activation behavior">
   Modify the [=EventTarget/activation behavior=] of <{area}> elements by introducing the |event| argument and replacing the <a spec="HTML" lt="follows a hyperlink">follow the hyperlink</a> step with the following:
 
   1. Otherwise:
-    1. Let |isUserInitiated| be true if |event|'s {{Event/isTrusted}} attribute is initialized to true; otherwise, false.
-    1. <a spec="HTML" lt="follows a hyperlink">Follow the hyperlink</a> created by |element| with <i>[=follows a hyperlink/isUserInitiated=]</i> set to |isUserInitiated|.
+    1. Let |userInvolvement| be "<code>[=user navigation involvement/activation=]</code>" if |event|'s {{Event/isTrusted}} attribute is initialized to true; otherwise, "<code>[=user navigation involvement/none=]</code>".
+    1. <a spec="HTML" lt="follows a hyperlink">Follow the hyperlink</a> created by <var ignore>element</var> with |userInvolvement|.
 </div>
 
-<div algorithm="area activation behavior">
+<div algorithm="a activation behavior">
   Modify the [=EventTarget/activation behavior=] of <{a}> elements by replacing its <a spec="HTML" lt="follows a hyperlink">follow the hyperlink</a> step with the following:
 
   1. Otherwise:
-    1. Let |isUserInitiated| be true if |event|'s {{Event/isTrusted}} attribute is initialized to true; otherwise, false.
-    1. <a spec="HTML" lt="follows a hyperlink">Follow the hyperlink</a> created by |element| with <i>[=follows a hyperlink/isUserInitiated=]</i> set to |isUserInitiated|.
+    1. Let |userInvolvement| be "<code>[=user navigation involvement/activation=]</code>" if <var ignore>event</var>'s {{Event/isTrusted}} attribute is initialized to true; otherwise, "<code>[=user navigation involvement/none=]</code>".
+    1. <a spec="HTML" lt="follows a hyperlink">Follow the hyperlink</a> created by <var ignore>element</var> with |userInvolvement|.
 </div>
 
 Expand the section on "<a href="https://html.spec.whatwg.org/multipage/semantics.html#providing-users-with-a-means-to-follow-hyperlinks-created-using-the-link-element">Providing users with a means to follow hyperlinks created using the `link` element</a>" by adding the following sentence:
 
-<blockquote><ins>Such invocations of <a spec="HTML" lt="follows a hyperlink">follow the hyperlink</a> algorithm must set the <i>[=navigate/fromBrowserUI=]</i> argument to true.</ins></blockquote>
+<blockquote><ins>Such invocations of <a spec="HTML" lt="follows a hyperlink">follow the hyperlink</a> algorithm must set the <i>[=navigate/userInvolvement=]</i> argument to "<code>[=user navigation involvement/browser UI=]</code>".</ins></blockquote>
 
 TODO form submission user-initiated.
 
@@ -341,7 +350,7 @@ TODO form submission user-initiated.
 With the above infrastructure in place, we can actually fire and handle the {{AppHistory/navigate}} event in the following locations:
 
 <div algorithm="shared history push/replace steps">
-  Modify the <a spec="HTML">shared history push/replace state steps</a> by inserting the following steps right before the step that runs the <a spec="HTML">URL and history update steps</a>:
+  Modify the <a spec="HTML">shared history push/replace state steps</a> by inserting the following steps right before the step that runs the <a spec="HTML">URL and history update steps</a>.
 
   1. Let |appHistory| be <var ignore>history</var>'s [=relevant global object=]'s [=Window/app history=].
   1. Let |continue| be the result of [=firing a navigate event=] at |appHistory| given <var ignore>newURL</var>, with <i>[=fire a navigate event/isPush=]</i> set to <var ignore>isPush</var>, <i>[=fire a navigate event/isCrossDocument=]</i> set to false, <i>[=fire a navigate event/classicHistoryAPISerializedData=]</i> set to <var ignore>serializedData</var>, and <i>[=fire a navigate event/classicHistoryAPITitle=]</i> set to <var ignore>title</var>.
@@ -349,24 +358,24 @@ With the above infrastructure in place, we can actually fire and handle the {{Ap
 </div>
 
 <div algorithm="navigate to a fragment">
-  Modify the <a spec="HTML">navigate to a fragment</a> algorithm by prepending the following steps:
+  Modify the <a spec="HTML">navigate to a fragment</a> algorithm by prepending the following steps. Recall that per [[#user-initiated-patches]] we have introduced a |userInvolvement| argument.
 
   1. Let |appHistory| be the <a spec="HTML">current entry</a>'s <a spec="HTML" for="session history entry">document</a>'s [=relevant global object=]'s [=Window/app history=].
   1. Let |isPush| be true if <var ignore>historyHandling</var> is "<a spec="HTML" for="history handling behavior">`default`</a>"; otherwise, false.
-  1. Let |continue| be the result of [=firing a navigate event=] at |appHistory| given <var ignore>url</var>, with <i>[=fire a navigate event/isPush=]</i> set to |isPush|, <i>[=fire a navigate event/isCrossDocument=]</i> set to false, <i>[=fire a navigate event/isUserInitiated=]</i> set to <var ignore>isUserInitiated</var>, and <i>[=fire a navigate event/isFragmentNavigation=]</i> set to true.
+  1. Let |continue| be the result of [=firing a navigate event=] at |appHistory| given <var ignore>url</var>, with <i>[=fire a navigate event/isPush=]</i> set to |isPush|, <i>[=fire a navigate event/isCrossDocument=]</i> set to false, <i>[=fire a navigate event/userInvolvement=]</i> set to |userInvolvement|, and <i>[=fire a navigate event/isFragmentNavigation=]</i> set to true.
   1. If |continue| is false, return.
 </div>
 
 <div algorithm="navigate" id="navigate-modifications">
-  Modify the <a spec="HTML">navigate</a> algorithm by inserting the following step right before the step which goes [=in parallel=]:
+  Modify the <a spec="HTML">navigate</a> algorithm by inserting the following step right before the step which goes [=in parallel=]. Recall that per [[#user-initiated-patches]] we have introduced |userInvolvement| argument, and per [[#form-patches]] we have introduced a |entryList| argument.
 
-  1. If <var ignore>historyHandling</var> is not "<a for="history handling behavior">`entry update`</a>", and <var ignore>fromBrowserUI</var> is false, then:
+  1. If <var ignore>historyHandling</var> is not "<a for="history handling behavior">`entry update`</a>", and <var ignore>userInvolvement</var> is not "<code>[=user navigation involvement/browser UI=]</code>", then:
     1. Let |appHistory| be <var ignore>browsingContext</var>'s [=browsing context/active window=]'s [=Window/app history=].
     1. Let |isPush| be true if <var ignore>historyHandling</var> is "<a for="history handling behavior">`default`</a>"; otherwise, false.
-    1. Let |continue| be the result of [=firing a navigate event=] at |appHistory| given <var ignore>url</var>, with <i>[=fire a navigate event/isPush=]</i> set to |isPush|, <i>[=fire a navigate event/isUserInitiated=]</i> set to <var ignore>isUserInitiated</var>, <i>[=fire a navigate event/isCrossDocument=]</i> set to true, and <i>[=fire a navigate event/formDataEntryList=]</i> set to <var ignore>entryList</var>.
+    1. Let |continue| be the result of [=firing a navigate event=] at |appHistory| given <var ignore>url</var>, with <i>[=fire a navigate event/isPush=]</i> set to |isPush|, <i>[=fire a navigate event/userInvolvement=]</i> set to |userInvolvement|, <i>[=fire a navigate event/isCrossDocument=]</i> set to true, and <i>[=fire a navigate event/formDataEntryList=]</i> set to |entryList|.
     1. If |continue| is false, return.
 
-    <p class="note">[=User agent=]-specific mechanisms that cause <a spec="HTML" lt="navigate to a fragment">fragment navigations</a> <em>do</em> fire the {{AppHistory/navigate}} event; those are handled as part of the <a spec="HTML">navigate to a fragment</a> algorithm, which does not have this condition.
+    <p class="note">"<code>[=user navigation involvement/browser UI=]</code>" navigations that cause <a spec="HTML" lt="navigate to a fragment">fragment navigations</a> <em>do</em> fire the {{AppHistory/navigate}} event; those are handled as part of the <a spec="HTML">navigate to a fragment</a> algorithm called earlier in <a spec="HTML">navigate</a>, which is not guarded by this condition.
 
     <p class="note">"<a for="history handling behavior">`entry update`</a>" is excluded since {{AppHistory/navigate}} would have fired earlier as part of <a spec="HTML">traversing the history by a delta</a>.
 
@@ -374,10 +383,10 @@ With the above infrastructure in place, we can actually fire and handle the {{Ap
 </div>
 
 <div algorithm="traverse the history by a delta">
-  Modify the <a spec="HTML">traverse the history by a delta</a> algorithm by inserting the following steps inside the queued task, before the call to <a spec="HTML">traverse the history</a>:
+  Modify the <a spec="HTML">traverse the history by a delta</a> algorithm by inserting the following steps inside the queued task, before the call to <a spec="HTML">traverse the history</a>. Recall that per [[#user-initiated-patches]] we have introduced a |userInvolvement| argument.
 
   1. Let |appHistory| be <var ignore>specified browsing context</var>'s [=browsing context/active window=]'s [=Window/app history=].
   1. Let |isCrossDocument| be true if <var ignore>specified browsing context</var>'s [=active document=] is different from <var ignore>specified entry</var>'s [=session history entry/document=]; otherwise, false.
-  1. Let |continue| be the result of [=firing a navigate event=] at |appHistory| given <var ignore>url</var>, with <i>[=fire a navigate event/isPush=]</i> set to false, <i>[=fire a navigate event/isBackForward=]</i> set to true, <i>[=fire a navigate event/isCrossDocument=]</i> set to |isCrossDocument|, and <i>[=fire a navigate event/isBrowserUI=]</i> and <i>[=fire a navigate event/isUserInitiated=]</i> both set to <var ignore>fromBrowserUI</var>.
+  1. Let |continue| be the result of [=firing a navigate event=] at |appHistory| given <var ignore>url</var>, with <i>[=fire a navigate event/isPush=]</i> set to false, <i>[=fire a navigate event/isBackForward=]</i> set to true, <i>[=fire a navigate event/isCrossDocument=]</i> set to |isCrossDocument|, and <i>[=fire a navigate event/userInvolvement=]</i> set to |userInvolvement|.
   1. If |continue| is false, abort these steps.
 </div>

--- a/spec.bs
+++ b/spec.bs
@@ -54,6 +54,19 @@ dfn var {
   font-style: italic;
 }
 
+/* WHATWG-style <hr>s, instead of WICG-style. Specific selector is necessary to override WICG styles. */
+:not(.head) > :not(.head) + hr {
+  display: block;
+  background: none;
+  border: none;
+  padding: 0;
+  margin: 3em 0;
+  height: auto;
+}
+:not(.head) > :not(.head) + hr::before {
+  content: none;
+}
+
 /* domintro from https://resources.whatwg.org/standard.css */
 .domintro {
   position: relative;
@@ -257,7 +270,51 @@ A [=URL=] is <dfn>rewritable</dfn> relative to another [=URL=] if they differ in
 
 <h2 id="navigate-patches">Patches to fire the {{AppHistory/navigate}} event</h2>
 
-The following section details monkeypatches to [[!HTML]] that cause the {{AppHistory/navigate}} event to be fired appropriately, and for canceling the event to cancel the navigation.
+The following section details monkeypatches to [[!HTML]] that cause the {{AppHistory/navigate}} event to be fired appropriately, and for canceling the event to cancel the navigation. The first couple of sections detail slight tweaks to existing algorithms to pass through useful information. Then, [[#navigate-algorithm-patches]] contains the actual firing of the event.
+
+<h3 id="form-patches">Form submission patches</h3>
+
+To properly thread the form entry list from its creation through to {{AppHistoryNavigateEvent}}'s {{AppHistoryNavigateEvent/formData}} property, we need the following modifications:
+
+<div algorithm="form navigate">
+  Modify the <a spec="HTML">navigate</a> algorithm to take a [=list=] of [=FormData/entries=] or null <dfn for="navigate">|entryList|</dfn> (default null), replacing its |navigationType| parameter. Then insert a step somewhere early in the algorithm to convert this back into the |navigationType| variable used by the [=in parallel=] section that is ultimately passed to [[CSP]]:
+
+  1. Let |navigationType| be "`form-submission`" if |entryList| is non-null; otherwise, "`other`".
+</div>
+
+<div algorithm="plan to navigate">
+  Modify the <a spec="HTML">plan to navigate</a> algorithm to take an additional optional argument |entryList| (default null). Then, modify the step which calls <a spec="HTML">navigate</a> to pass it along:
+
+  1. <a spec="HTML">Navigate</a> <var ignore>target browsing context</var> to <var ignore>destination</var>, with <i>[=navigate/historyHandling=]</i> set to <var ignore>historyHandling</var> <del>and <i>[=navigate/navigationType=]</i> set to "`form-submission`"</del><ins><i>[=navigate/entryList=]</i> set to |entryList|</ins>.
+</div>
+
+<div algorithm="submit as entity body">
+  Modify the <a spec="HTML">submit as entity body</a> algorithm to pass <var ignore>entry list</var> along to <a spec="HTML">plan to navigate</a> as a second argument.
+</div>
+
+<h3 id="user-initiated-patches">User-initiated patches</h3>
+
+To more rigorously specify when a navigation is user-initiated, both for the purposes of the {{AppHistoryNavigateEvent}}'s {{AppHistoryNavigateEvent/userInitiated}} property and for prohibiting interception of certain types of browser-UI-initiated navigations, we need the following modifications:
+
+Modify the <a spec="HTML">traverse the history by a delta</a> argument to take an optional named argument <dfn for="traverse the history by a delta"><var ignore>fromBrowserUI</var></dfn> (default false). Then, update the paragraph talking about user-initiated navigation as follows:
+
+<blockquote>
+  When the user navigates through a [=browsing context=], e.g. using a browser's back and forward buttons, the user agent must <a spec="HTML">traverse the history by a delta</a> with a delta equivalent to the action specified by the user<del> and</del><ins>,</ins> the browsing context being operated on<ins>, and <i>[=traverse the history by a delta/fromBrowserUI=]</i> set to true</ins>.
+</blockquote>
+
+Modify the <a spec="HTML">navigate</a> algorithm to take an optional named argument <dfn for="navigate"><var ignore>fromBrowserUI</var></dfn> (default false). Then, update the paragraph talking about user-initiated navigation as follows:
+
+<blockquote>
+  A user agent may provide various ways for the user to explicitly cause a browsing context to navigate, in addition to those defined in this specification.<ins> Such cases must set the <i>[=navigate/fromBrowserUI=]</i> argument to true.
+</blockquote>
+
+<p class="note">This partially solves <a href="https://github.com/whatwg/html/issues/5381">whatwg/html#5381</a>, and it'd be ideal to update the \`<a http-header><code>Sec-Fetch-Dest</code></a>\` spec at the same time.</p>
+
+Modify the <a spec="HTML">navigate to a fragment</a> algorithm to take a new <var ignore>fromBrowserUI</var> argument as its last argument. Then, update the call to it from <a spec="HTML">navigate</a> to pass along its own <var ignore>fromBrowserUI</var> value.
+
+<h3 id="navigate-algorithm-patches">Navigation algorithm updates</h3>
+
+With the above infrastructure in place, we can actually fire and handle the {{AppHistory/navigate}} event in the following locations:
 
 <div algorithm="shared history push/replace steps">
   Modify the <a spec="HTML">shared history push/replace state steps</a> by inserting the following steps right before the step that runs the <a spec="HTML">URL and history update steps</a>:
@@ -279,7 +336,7 @@ The following section details monkeypatches to [[!HTML]] that cause the {{AppHis
 <div algorithm="navigate" id="navigate-modifications">
   Modify the <a spec="HTML">navigate</a> algorithm by inserting the following step right before the step which goes [=in parallel=]:
 
-  1. If <var ignore>historyHandling</var> is not "<a for="history handling behavior">`entry update`</a>", and this navigation was not initiated by the user explictly causing <var ignore>browsingContext</var> to navigate using [=user agent=]-specific mechanisms but instead was initiated by algorithms elsewhere in this specification, then:
+  1. If <var ignore>historyHandling</var> is not "<a for="history handling behavior">`entry update`</a>", and <var ignore>fromBrowserUI</var> is false, then:
     1. Let |appHistory| be <var ignore>browsingContext</var>'s [=browsing context/active window=]'s [=Window/app history=].
     1. Let |isPush| be true if <var ignore>historyHandling</var> is "<a for="history handling behavior">`default`</a>"; otherwise, false.
     1. Let |continue| be the result of [=firing a navigate event=] at |appHistory| given <var ignore>url</var>, with <i>[=fire a navigate event/isPush=]</i> set to |isPush|, <i>[=fire a navigate event/isUserInitiated=]</i> set to ???TODO, <i>[=fire a navigate event/isCrossDocument=]</i> set to true, and <i>[=fire a navigate event/formDataEntryList=]</i> set to <var ignore>entryList</var>.
@@ -296,30 +353,7 @@ The following section details monkeypatches to [[!HTML]] that cause the {{AppHis
   Modify the <a spec="HTML">traverse the history by a delta</a> algorithm by inserting the following steps inside the queued task, before the call to <a spec="HTML">traverse the history</a>:
 
   1. Let |appHistory| be <var ignore>specified browsing context</var>'s [=browsing context/active window=]'s [=Window/app history=].
-  1. Let |isBrowserUI| be true if this traversal was initiated by the user explictly causing <var ignore>browsingContext</var> to navigate using [=user agent=]-specific mechanisms (e.g., the browser's back and forward buttons); otherwise, false.
   1. Let |isCrossDocument| be true if <var ignore>specified browsing context</var>'s [=active document=] is different from <var ignore>specified entry</var>'s [=session history entry/document=]; otherwise, false.
-  1. Let |continue| be the result of [=firing a navigate event=] at |appHistory| given <var ignore>url</var>, with <i>[=fire a navigate event/isPush=]</i> set to false, <i>[=fire a navigate event/isBackForward=]</i> set to true, <i>[=fire a navigate event/isCrossDocument=]</i> set to |isCrossDocument|, and <i>[=fire a navigate event/isBrowserUI=]</i> and <i>[=fire a navigate event/isUserInitiated=]</i> both set to |isBrowserUI|.
+  1. Let |continue| be the result of [=firing a navigate event=] at |appHistory| given <var ignore>url</var>, with <i>[=fire a navigate event/isPush=]</i> set to false, <i>[=fire a navigate event/isBackForward=]</i> set to true, <i>[=fire a navigate event/isCrossDocument=]</i> set to |isCrossDocument|, and <i>[=fire a navigate event/isBrowserUI=]</i> and <i>[=fire a navigate event/isUserInitiated=]</i> both set to <var ignore>fromBrowserUI</var>.
   1. If |continue| is false, abort these steps.
-</div>
-
-<h3 id="form-patches">Form submission patches</h3>
-
-To properly thread the form entry list from its creation through to {{AppHistoryNavigateEvent}}'s {{AppHistoryNavigateEvent/formData}} property, we need the following modifications:
-
-<div algorithm="form navigate">
-  Modify the <a spec="HTML">navigate</a> algorithm to take a [=list=] of [=FormData/entries=] or null <dfn for="navigate">|entryList|</dfn> (default null), replacing its |navigationType| parameter. Then insert a step somewhere early in the algorithm to convert this back into the |navigationType| variable used by the [=in parallel=] section that is ultimately passed to [[CSP]]:
-
-  1. Let |navigationType| be "`form-submission`" if |entryList| is non-null; otherwise, "`other`".
-
-  Our <a href="navigate-modifications">modifications above</a> then use <i>[=navigate/entryList=]</i>.
-</div>
-
-<div algorithm="plan to navigate">
-  Modify the <a spec="HTML">plan to navigate</a> algorithm to take an additional optional argument |entryList| (default null). Then, modify the step which calls <a spec="HTML">navigate</a> to pass it along:
-
-  1. <a spec="HTML">Navigate</a> <var ignore>target browsing context</var> to <var ignore>destination</var>, with <i>[=navigate/historyHandling=]</i> set to <var ignore>historyHandling</var> <del>and <i>[=navigate/navigationType=]</i> set to "`form-submission`"</del><ins><i>[=navigate/entryList=]</i> set to |entryList|</ins>.
-</div>
-
-<div algorithm="submit as entity body">
-  Modify the <a spec="HTML">submit as entity body</a> algorithm to pass <var ignore>entry list</var> along to <a spec="HTML">plan to navigate</a> as a second argument.
 </div>

--- a/spec.bs
+++ b/spec.bs
@@ -238,7 +238,7 @@ An {{AppHistoryNavigateEvent}} has an associated [=URL=] <dfn for="AppHistoryNav
 <hr>
 
 <div algorithm="fire a navigate event">
-  To <dfn>fire a `navigate` event</dfn> at an {{AppHistory}} |appHistory| given a [=URL=] |destinationURL|, a boolean <dfn for="fire a navigate event">|isPush|</dfn>, a boolean <dfn for="fire a navigate event">|isCrossDocument|</dfn>, an optional [=user navigation involvement=] <dfn for="fire a navigate event">|userInvolvement|</dfn> (default "<code>[=user navigation involvement/none=]</code>"), an optional boolean <dfn for="fire a navigate event">|isHistoryTraversal|</dfn> (default false), an optional boolean <dfn for="fire a navigate event">|isFragmentNavigation|</dfn> (default false), an optional value |navigateInfo| (default null), an optional [=list=] of [=FormData/entries=] or null <dfn for="fire a navigate event">|formDataEntryList|</dfn> (default null), an optional [=serialized state=]-or-null <dfn for="fire a navigate event">|classicHistoryAPISerializedData|</dfn> (default null), and an optional string-or-null <dfn for="fire a navigate event">|classicHistoryAPITitle|</dfn> (default null):
+  To <dfn>fire a `navigate` event</dfn> at an {{AppHistory}} |appHistory| given a [=URL=] |destinationURL|, a boolean <dfn for="fire a navigate event">|isPush|</dfn>, a boolean <dfn for="fire a navigate event">|isSameDocument|</dfn>, an optional [=user navigation involvement=] <dfn for="fire a navigate event">|userInvolvement|</dfn> (default "<code>[=user navigation involvement/none=]</code>"), an optional boolean <dfn for="fire a navigate event">|isHistoryTraversal|</dfn> (default false), an optional boolean <dfn for="fire a navigate event">|isFragmentNavigation|</dfn> (default false), an optional value |navigateInfo| (default null), an optional [=list=] of [=FormData/entries=] or null <dfn for="fire a navigate event">|formDataEntryList|</dfn> (default null), an optional [=serialized state=]-or-null <dfn for="fire a navigate event">|classicHistoryAPISerializedData|</dfn> (default null), and an optional string-or-null <dfn for="fire a navigate event">|classicHistoryAPITitle|</dfn> (default null):
 
   1. Let |event| be the result of [=creating an event=] given {{AppHistoryNavigateEvent}}, in the [=relevant Realm=] of |appHistory|.
   1. Set |event|'s [=AppHistoryNavigateEvent/destination URL=] to |destinationURL|.
@@ -250,7 +250,7 @@ An {{AppHistoryNavigateEvent}} has an associated [=URL=] <dfn for="AppHistoryNav
 <!--  1. Initialize |event|'s {{AppHistoryNavigateEvent/signal}} to a [=new=] {{AbortSignal}} created in the [=relevant Realm=] of |appHistory|.-->
   1. Initialize |event|'s {{AppHistoryNavigateEvent/info}} to |navigateInfo|.
   1. Let |currentURL| be |appHistory|'s [=relevant global object=]'s [=associated document=]'s [=Document/URL=].
-  1. If |destinationURL| is [=rewritable=] relative to |currentURL|, and either |isCrossDocument| is false or |isHistoryTraversal| is false, then initialize |event|'s {{AppHistoryNavigateEvent/canRespond}} to true. Otherwise, initialize it to false.
+  1. If |destinationURL| is [=rewritable=] relative to |currentURL|, and either |isSameDocument| is true or |isHistoryTraversal| is false, then initialize |event|'s {{AppHistoryNavigateEvent/canRespond}} to true. Otherwise, initialize it to false.
   1. If either |userInvolvement| is not "<code>[=user navigation involvement/browser UI=]</code>" or |isHistoryTraversal| is false, then initialize |event|'s {{Event/cancelable}} to true.
   1. If |userInvolvement| is "<code>[=user navigation involvement/none=]</code>", then initialize |event|'s {{AppHistoryNavigateEvent/userInitiated}} to false. Otherwise, initialize it to true.
   1. If |formDataEntryList| is not null, then initialize |event|'s {{AppHistoryNavigateEvent/formData}} to a [=new=] {{FormData}} created in the [=relevant Realm=] of |appHistory|, associated to |formDataEntryList|. Otherwise, initialize it to null.
@@ -369,7 +369,7 @@ With the above infrastructure in place, we can actually fire and handle the {{Ap
   Modify the <a spec="HTML">shared history push/replace state steps</a> by inserting the following steps right before the step that runs the <a spec="HTML">URL and history update steps</a>.
 
   1. Let |appHistory| be <var ignore>history</var>'s [=relevant global object=]'s [=Window/app history=].
-  1. Let |continue| be the result of [=firing a navigate event=] at |appHistory| given <var ignore>newURL</var>, with <i>[=fire a navigate event/isPush=]</i> set to <var ignore>isPush</var>, <i>[=fire a navigate event/isCrossDocument=]</i> set to false, <i>[=fire a navigate event/classicHistoryAPISerializedData=]</i> set to <var ignore>serializedData</var>, and <i>[=fire a navigate event/classicHistoryAPITitle=]</i> set to <var ignore>title</var>.
+  1. Let |continue| be the result of [=firing a navigate event=] at |appHistory| given <var ignore>newURL</var>, with <i>[=fire a navigate event/isPush=]</i> set to <var ignore>isPush</var>, <i>[=fire a navigate event/isSameDocument=]</i> set to true, <i>[=fire a navigate event/classicHistoryAPISerializedData=]</i> set to <var ignore>serializedData</var>, and <i>[=fire a navigate event/classicHistoryAPITitle=]</i> set to <var ignore>title</var>.
   1. If |continue| is false, return.
 </div>
 
@@ -378,7 +378,7 @@ With the above infrastructure in place, we can actually fire and handle the {{Ap
 
   1. Let |appHistory| be the <a spec="HTML">current entry</a>'s <a spec="HTML" for="session history entry">document</a>'s [=relevant global object=]'s [=Window/app history=].
   1. Let |isPush| be true if <var ignore>historyHandling</var> is "<a spec="HTML" for="history handling behavior">`default`</a>"; otherwise, false.
-  1. Let |continue| be the result of [=firing a navigate event=] at |appHistory| given <var ignore>url</var>, with <i>[=fire a navigate event/isPush=]</i> set to |isPush|, <i>[=fire a navigate event/isCrossDocument=]</i> set to false, <i>[=fire a navigate event/userInvolvement=]</i> set to |userInvolvement|, and <i>[=fire a navigate event/isFragmentNavigation=]</i> set to true.
+  1. Let |continue| be the result of [=firing a navigate event=] at |appHistory| given <var ignore>url</var>, with <i>[=fire a navigate event/isPush=]</i> set to |isPush|, <i>[=fire a navigate event/isSameDocument=]</i> set to true, <i>[=fire a navigate event/userInvolvement=]</i> set to |userInvolvement|, and <i>[=fire a navigate event/isFragmentNavigation=]</i> set to true.
   1. If |continue| is false, return.
 </div>
 
@@ -394,7 +394,7 @@ With the above infrastructure in place, we can actually fire and handle the {{Ap
 
       1. Let |appHistory| be <var ignore>browsingContext</var>'s [=browsing context/active window=]'s [=Window/app history=].
       1. Let |isPush| be true if <var ignore>historyHandling</var> is "<a for="history handling behavior">`default`</a>"; otherwise, false.
-      1. Let |continue| be the result of [=firing a navigate event=] at |appHistory| given <var ignore>url</var>, with <i>[=fire a navigate event/isPush=]</i> set to |isPush|, <i>[=fire a navigate event/isCrossDocument=]</i> set to true, <i>[=fire a navigate event/userInvolvement=]</i> set to |userInvolvement|, and <i>[=fire a navigate event/formDataEntryList=]</i> set to |entryList|.
+      1. Let |continue| be the result of [=firing a navigate event=] at |appHistory| given <var ignore>url</var>, with <i>[=fire a navigate event/isPush=]</i> set to |isPush|, <i>[=fire a navigate event/isSameDocument=]</i> set to false, <i>[=fire a navigate event/userInvolvement=]</i> set to |userInvolvement|, and <i>[=fire a navigate event/formDataEntryList=]</i> set to |entryList|.
       1. If |continue| is false, return.
 
     <p class="note">"<code>[=user navigation involvement/browser UI=]</code>" navigations that cause <a spec="HTML" lt="navigate to a fragment">fragment navigations</a> <em>do</em> fire the {{AppHistory/navigate}} event; those are handled as part of the <a spec="HTML">navigate to a fragment</a> algorithm called earlier in <a spec="HTML">navigate</a>, which is not guarded by this condition.
@@ -406,8 +406,8 @@ With the above infrastructure in place, we can actually fire and handle the {{Ap
   Modify the <a spec="HTML">traverse the history by a delta</a> algorithm by inserting the following steps inside the queued task, before the call to <a spec="HTML">traverse the history</a>. Recall that per [[#user-initiated-patches]] we have introduced a |userInvolvement| argument.
 
   1. Let |appHistory| be <var ignore>specified browsing context</var>'s [=browsing context/active window=]'s [=Window/app history=].
-  1. Let |isCrossDocument| be true if <var ignore>specified browsing context</var>'s [=active document=] is different from <var ignore>specified entry</var>'s [=session history entry/document=]; otherwise, false.
-  1. If either |isCrossDocument| is false or |userInvolvement| is not "<code>[=user navigation involvement/browser UI=]</code>", then:
-    1. Let |continue| be the result of [=firing a navigate event=] at |appHistory| given <var ignore>url</var>, with <i>[=fire a navigate event/isPush=]</i> set to false, <i>[=fire a navigate event/isCrossDocument=]</i> set to |isCrossDocument|, <i>[=fire a navigate event/userInvolvement=]</i> set to |userInvolvement|, and <i>[=fire a navigate event/isHistoryTraversal=]</i> set to true.
+  1. Let |isSameDocument| be true if <var ignore>specified browsing context</var>'s [=active document=] equals <var ignore>specified entry</var>'s [=session history entry/document=]; otherwise, false.
+  1. If either |isSameDocument| is true or |userInvolvement| is not "<code>[=user navigation involvement/browser UI=]</code>", then:
+    1. Let |continue| be the result of [=firing a navigate event=] at |appHistory| given <var ignore>url</var>, with <i>[=fire a navigate event/isPush=]</i> set to false, <i>[=fire a navigate event/isSameDocument=]</i> set to |isSameDocument|, <i>[=fire a navigate event/userInvolvement=]</i> set to |userInvolvement|, and <i>[=fire a navigate event/isHistoryTraversal=]</i> set to true.
     1. If |continue| is false, abort these steps.
 </div>

--- a/spec.bs
+++ b/spec.bs
@@ -395,6 +395,7 @@ With the above infrastructure in place, we can actually fire and handle the {{Ap
 
   1. Let |appHistory| be <var ignore>specified browsing context</var>'s [=browsing context/active window=]'s [=Window/app history=].
   1. Let |isCrossDocument| be true if <var ignore>specified browsing context</var>'s [=active document=] is different from <var ignore>specified entry</var>'s [=session history entry/document=]; otherwise, false.
-  1. Let |continue| be the result of [=firing a navigate event=] at |appHistory| given <var ignore>url</var>, with <i>[=fire a navigate event/isPush=]</i> set to false, <i>[=fire a navigate event/isCrossDocument=]</i> set to |isCrossDocument|, <i>[=fire a navigate event/userInvolvement=]</i> set to |userInvolvement|, and <i>[=fire a navigate event/isHistoryTraversal=]</i> set to true.
-  1. If |continue| is false, abort these steps.
+  1. If either |isCrossDocument| is false or |userInvolvement| is not "<code>[=user navigation involvement/browser UI=]</code>", then:
+    1. Let |continue| be the result of [=firing a navigate event=] at |appHistory| given <var ignore>url</var>, with <i>[=fire a navigate event/isPush=]</i> set to false, <i>[=fire a navigate event/isCrossDocument=]</i> set to |isCrossDocument|, <i>[=fire a navigate event/userInvolvement=]</i> set to |userInvolvement|, and <i>[=fire a navigate event/isHistoryTraversal=]</i> set to true.
+    1. If |continue| is false, abort these steps.
 </div>

--- a/spec.bs
+++ b/spec.bs
@@ -409,7 +409,12 @@ With the above infrastructure in place, we can actually fire and handle the {{Ap
   1. Let |appHistory| be <var ignore>specified browsing context</var>'s [=browsing context/active window=]'s [=Window/app history=].
   1. Let |isSameDocument| be true if <var ignore>specified browsing context</var>'s [=active document=] equals <var ignore>specified entry</var>'s [=session history entry/document=]; otherwise, false.
   1. If either |isSameDocument| is true or |userInvolvement| is not "<code>[=user navigation involvement/browser UI=]</code>", then:
-    1. Let |hashChange| be true if |isSameDocument| is true and <var ignore>specified browsing context</var>'s [=active document=]'s [=Document/URL=]'s [=url/fragment=] is not [=string/is|identical to=] <var ignore>specified entry</var>'s [=session history entry/URL=]'s [=url/fragment=]; otherwise false.
+    1. Let |hashChange| be true if all of the following are true:
+      * |isSameDocument| is true;
+      * <var ignore>specified browsing context</var>'s [=active document=]'s [=Document/URL=] [=url/equals=] <var ignore>specified entry</var>'s [=session history entry/URL=] with <i>[=url/equals/exclude fragments=]</i> set to true; and
+      * <var ignore>specified browsing context</var>'s [=active document=]'s [=Document/URL=]'s [=url/fragment=] is not [=string/is|identical to=] <var ignore>specified entry</var>'s [=session history entry/URL=]'s [=url/fragment=].
+
+      Otherwise, let it be false.
     1. Let |continue| be the result of [=firing a navigate event=] at |appHistory| given <var ignore>url</var>, with <i>[=fire a navigate event/isPush=]</i> set to false, <i>[=fire a navigate event/isSameDocument=]</i> set to |isSameDocument|, <i>[=fire a navigate event/userInvolvement=]</i> set to |userInvolvement|, <i>[=fire a navigate event/isHistoryTraversal=]</i> set to true,  and <i>[=fire a navigate event/hashChange=]</i> set to |hashChange|.
     1. If |continue| is false, abort these steps.
 </div>

--- a/spec.bs
+++ b/spec.bs
@@ -31,6 +31,7 @@ spec: html; type: dfn; urlPrefix: https://html.spec.whatwg.org/multipage/
     text: isPush; url: history.html#uhus-ispush
   for: session history entry
     text: document; url: history.html#she-document
+    text: URL; url: history.html#she-url
   for: history handling behavior
     text: default; url: browsing-the-web.html#hh-default
     text: entry update; url: browsing-the-web.html#hh-entry-update
@@ -238,7 +239,7 @@ An {{AppHistoryNavigateEvent}} has an associated [=URL=] <dfn for="AppHistoryNav
 <hr>
 
 <div algorithm="fire a navigate event">
-  To <dfn>fire a `navigate` event</dfn> at an {{AppHistory}} |appHistory| given a [=URL=] |destinationURL|, a boolean <dfn for="fire a navigate event">|isPush|</dfn>, a boolean <dfn for="fire a navigate event">|isSameDocument|</dfn>, an optional [=user navigation involvement=] <dfn for="fire a navigate event">|userInvolvement|</dfn> (default "<code>[=user navigation involvement/none=]</code>"), an optional boolean <dfn for="fire a navigate event">|isHistoryTraversal|</dfn> (default false), an optional boolean <dfn for="fire a navigate event">|isFragmentNavigation|</dfn> (default false), an optional value |navigateInfo| (default null), an optional [=list=] of [=FormData/entries=] or null <dfn for="fire a navigate event">|formDataEntryList|</dfn> (default null), an optional [=serialized state=]-or-null <dfn for="fire a navigate event">|classicHistoryAPISerializedData|</dfn> (default null), and an optional string-or-null <dfn for="fire a navigate event">|classicHistoryAPITitle|</dfn> (default null):
+  To <dfn>fire a `navigate` event</dfn> at an {{AppHistory}} |appHistory| given a [=URL=] |destinationURL|, a boolean <dfn for="fire a navigate event">|isPush|</dfn>, a boolean <dfn for="fire a navigate event">|isSameDocument|</dfn>, an optional [=user navigation involvement=] <dfn for="fire a navigate event">|userInvolvement|</dfn> (default "<code>[=user navigation involvement/none=]</code>"), an optional boolean <dfn for="fire a navigate event">|isHistoryTraversal|</dfn> (default false), an optional boolean <dfn for="fire a navigate event">|hashChange|</dfn> (default false), an optional value |navigateInfo| (default null), an optional [=list=] of [=FormData/entries=] or null <dfn for="fire a navigate event">|formDataEntryList|</dfn> (default null), an optional [=serialized state=]-or-null <dfn for="fire a navigate event">|classicHistoryAPISerializedData|</dfn> (default null), and an optional string-or-null <dfn for="fire a navigate event">|classicHistoryAPITitle|</dfn> (default null):
 
   1. Let |event| be the result of [=creating an event=] given {{AppHistoryNavigateEvent}}, in the [=relevant Realm=] of |appHistory|.
   1. Set |event|'s [=AppHistoryNavigateEvent/destination URL=] to |destinationURL|.
@@ -246,7 +247,7 @@ An {{AppHistoryNavigateEvent}} has an associated [=URL=] <dfn for="AppHistoryNav
   1. Set |event|'s [=AppHistoryNavigateEvent/classic history API serialized data=] to |classicHistoryAPISerializedData|.
   1. Set |event|'s [=AppHistoryNavigateEvent/classic history API title=] to |classicHistoryAPITitle|.
   1. Initialize |event|'s {{Event/type}} to {{AppHistory/navigate}}.
-  1. Initialize |event|'s {{AppHistoryNavigateEvent/hashChange}} to |isFragmentNavigation|.
+  1. Initialize |event|'s {{AppHistoryNavigateEvent/hashChange}} to |hashChange|.
 <!--  1. Initialize |event|'s {{AppHistoryNavigateEvent/signal}} to a [=new=] {{AbortSignal}} created in the [=relevant Realm=] of |appHistory|.-->
   1. Initialize |event|'s {{AppHistoryNavigateEvent/info}} to |navigateInfo|.
   1. Let |currentURL| be |appHistory|'s [=relevant global object=]'s [=associated document=]'s [=Document/URL=].
@@ -378,7 +379,7 @@ With the above infrastructure in place, we can actually fire and handle the {{Ap
 
   1. Let |appHistory| be the <a spec="HTML">current entry</a>'s <a spec="HTML" for="session history entry">document</a>'s [=relevant global object=]'s [=Window/app history=].
   1. Let |isPush| be true if <var ignore>historyHandling</var> is "<a spec="HTML" for="history handling behavior">`default`</a>"; otherwise, false.
-  1. Let |continue| be the result of [=firing a navigate event=] at |appHistory| given <var ignore>url</var>, with <i>[=fire a navigate event/isPush=]</i> set to |isPush|, <i>[=fire a navigate event/isSameDocument=]</i> set to true, <i>[=fire a navigate event/userInvolvement=]</i> set to |userInvolvement|, and <i>[=fire a navigate event/isFragmentNavigation=]</i> set to true.
+  1. Let |continue| be the result of [=firing a navigate event=] at |appHistory| given <var ignore>url</var>, with <i>[=fire a navigate event/isPush=]</i> set to |isPush|, <i>[=fire a navigate event/isSameDocument=]</i> set to true, <i>[=fire a navigate event/userInvolvement=]</i> set to |userInvolvement|, and <i>[=fire a navigate event/hashChange=]</i> set to true.
   1. If |continue| is false, return.
 </div>
 
@@ -408,6 +409,7 @@ With the above infrastructure in place, we can actually fire and handle the {{Ap
   1. Let |appHistory| be <var ignore>specified browsing context</var>'s [=browsing context/active window=]'s [=Window/app history=].
   1. Let |isSameDocument| be true if <var ignore>specified browsing context</var>'s [=active document=] equals <var ignore>specified entry</var>'s [=session history entry/document=]; otherwise, false.
   1. If either |isSameDocument| is true or |userInvolvement| is not "<code>[=user navigation involvement/browser UI=]</code>", then:
-    1. Let |continue| be the result of [=firing a navigate event=] at |appHistory| given <var ignore>url</var>, with <i>[=fire a navigate event/isPush=]</i> set to false, <i>[=fire a navigate event/isSameDocument=]</i> set to |isSameDocument|, <i>[=fire a navigate event/userInvolvement=]</i> set to |userInvolvement|, and <i>[=fire a navigate event/isHistoryTraversal=]</i> set to true.
+    1. Let |hashChange| be true if |isSameDocument| is true and <var ignore>specified browsing context</var>'s [=active document=]'s [=Document/URL=]'s [=url/fragment=] is not [=string/is|identical to=] <var ignore>specified entry</var>'s [=session history entry/URL=]'s [=url/fragment=]; otherwise false.
+    1. Let |continue| be the result of [=firing a navigate event=] at |appHistory| given <var ignore>url</var>, with <i>[=fire a navigate event/isPush=]</i> set to false, <i>[=fire a navigate event/isSameDocument=]</i> set to |isSameDocument|, <i>[=fire a navigate event/userInvolvement=]</i> set to |userInvolvement|, <i>[=fire a navigate event/isHistoryTraversal=]</i> set to true,  and <i>[=fire a navigate event/hashChange=]</i> set to |hashChange|.
     1. If |continue| is false, abort these steps.
 </div>

--- a/spec.bs
+++ b/spec.bs
@@ -29,6 +29,10 @@ spec: html; type: dfn; urlPrefix: https://html.spec.whatwg.org/multipage/
     text: serializedData; url: history.html#uhus-serializeddata
     text: title; url: history.html#uhus-title
     text: isPush; url: history.html#uhus-ispush
+  for: session history entry
+    text: document; url: history.html#she-document
+  for: history handling behavior
+    text: default; url: browsing-the-web.html#hh-default
 </pre>
 
 <style>
@@ -40,6 +44,10 @@ spec: html; type: dfn; urlPrefix: https://html.spec.whatwg.org/multipage/
   font-size: smaller;
   padding: 4px 10px;
   z-index: 4;
+}
+
+dfn var {
+  font-style: italic;
 }
 
 /* domintro from https://resources.whatwg.org/standard.css */
@@ -210,8 +218,8 @@ An {{AppHistoryNavigateEvent}} has an associated [=URL=] <dfn for="AppHistoryNav
 
 <hr>
 
-<div algorithm>
-  To <dfn>fire a `navigate` event</dfn> at an {{AppHistory}} |appHistory| given a [=URL=] |destinationURL|, a boolean |isPush|, a boolean |isCrossDocument|, a boolean |isBackForward|, a boolean |isBrowserUI|, a boolean |isUserInitiated|, a boolean |isFragmentNavigation|, an optional value |navigateInfo| (default null), an optional [=list=] of [=FormData/entries=] |formDataEntryList|, an optional [=serialized state=]-or-null |classicHistoryAPISerializedData| (default null), and an optional string-or-null |classicHistoryAPITitle| (default null):
+<div algorithm="fire a navigate event">
+  To <dfn>fire a `navigate` event</dfn> at an {{AppHistory}} |appHistory| given a [=URL=] |destinationURL|, a boolean <dfn for="fire a navigate event">|isPush|</dfn>, a boolean <dfn for="fire a navigate event">|isCrossDocument|</dfn>, a boolean <dfn for="fire a navigate event">|isBackForward|</dfn> (default false), a boolean <dfn for="fire a navigate event">|isBrowserUI|</dfn> (default false), a boolean <dfn for="fire a navigate event">|isUserInitiated|</dfn> (default false), a boolean <dfn for="fire a navigate event">|isFragmentNavigation|</dfn> (default false), an optional value |navigateInfo| (default null), an optional [=list=] of [=FormData/entries=] |formDataEntryList|, an optional [=serialized state=]-or-null <dfn for="fire a navigate event">|classicHistoryAPISerializedData|</dfn> (default null), and an optional string-or-null <dfn for="fire a navigate event">|classicHistoryAPITitle|</dfn> (default null):
 
   1. Let |event| be the result of [=creating an event=] given {{AppHistoryNavigateEvent}}, in the [=relevant Realm=] of |appHistory|.
   1. Set |event|'s [=AppHistoryNavigateEvent/destination URL=] to |destinationURL|.
@@ -247,4 +255,47 @@ A [=URL=] is <dfn>rewritable</dfn> relative to another [=URL=] if they differ in
 
 The following section details monkeypatches to [[!HTML]] that cause the {{AppHistory/navigate}} event to be fired appropriately, and for canceling the event to cancel the navigation.
 
-TODO!
+<div algorithm="shared history push/replace steps">
+  Modify the <a spec="HTML">shared history push/replace state steps</a> by inserting the following steps right before the step that runs the <a spec="HTML">URL and history update steps</a>:
+
+  1. Let |appHistory| be <var ignore>history</var>'s [=relevant global object=]'s [=Window/app history=].
+  1. Let |continue| be the result of [=firing a navigate event=] at |appHistory| given <var ignore>newURL</var>, with <i>[=fire a navigate event/isPush=]</i> set to <var ignore>isPush</var>, <i>[=fire a navigate event/isCrossDocument=]</i> set to false, <i>[=fire a navigate event/classicHistoryAPISerializedData=]</i> set to <var ignore>serializedData</var>, and <i>[=fire a navigate event/classicHistoryAPITitle=]</i> set to <var ignore>title</var>.
+  1. If |continue| is false, return.
+</div>
+
+TODO what about the last three steps of the <a spec="HTML">shared history push/replace state steps</a>? Probably those should run if respondWith() goes through?
+
+<div algorithm="navigate to a fragment">
+  Modify the <a spec="HTML">navigate to a fragment</a> algorithm by prepending the following steps:
+
+  1. Let |appHistory| be the <a spec="HTML">current entry</a>'s <a spec="HTML" for="session history entry">document</a>'s [=relevant global object=]'s [=Window/app history=].
+  1. Let |isPush| be true if <var ignore>historyHandling</var> is "<a spec="HTML" for="history handling behavior">`default`</a>"; otherwise, false.
+  1. Let |continue| be the result of [=firing a navigate event=] at |appHistory| given <var ignore>url</var>, with <i>[=fire a navigate event/isPush=]</i> set to |isPush|, <i>[=fire a navigate event/isCrossDocument=]</i> set to false, <i>[=fire a navigate event/isUserInitiated=]</i> set to ???TODO, and <i>[=fire a navigate event/isFragmentNavigation=]</i> set to true.
+  1. If |continue| is false, return.
+</div>
+
+<div algorithm="navigate">
+  Modify the <a spec="HTML">navigate</a> algorithm by inserting the following step right before the step which goes [=in parallel=]:
+
+  1. If this navigation was not initiated by the user explictly causing <var ignore>browsingContext</var> to navigate using [=user agent=]-specific mechanisms, but instead was initiated by algorithms elsewhere in this specification, then:
+    1. Let |appHistory| be <var ignore>browsingContext</var>'s [=browsing context/active window=]'s [=Window/app history=].
+    1. Let |isPush| be true if <var ignore>historyHandling</var> is "<a spec="HTML" for="history handling behavior">`default`</a>"; otherwise, false.
+    1. Let |continue| be the result of [=firing a navigate event=] at |appHistory| given <var ignore>url</var>, with <i>[=fire a navigate event/isPush=]</i> set to |isPush|, <i>[=fire a navigate event/isUserInitiated=]</i> set to ???TODO, and <i>[=fire a navigate event/isCrossDocument=]</i> set to true.
+    1. If |continue| is false, return.
+
+    <p class="note">[=User agent=]-specific mechanisms that cause <a spec="HTML" lt="navigate to a fragment">fragment navigations</a> <em>do</em> fire the {{AppHistory/navigate}} event; those are handled as part of the <a spec="HTML">navigate to a fragment</a> algorithm, which does not have this condition.
+
+  TODO: exclude `about:blank` initial navigation cases.
+
+  TODO: form data??
+</div>
+
+<div algorithm="traverse the history by a delta">
+  Modify the <a spec="HTML">traverse the history by a delta</a> algorithm by inserting the following steps inside the queued task, before the call to <a spec="HTML">traverse the history</a>:
+
+  1. Let |appHistory| be <var ignore>specified browsing context</var>'s [=browsing context/active window=]'s [=Window/app history=].
+  1. Let |isBrowserUI| be true if this traversal was initiated by the user explictly causing <var ignore>browsingContext</var> to navigate using [=user agent=]-specific mechanisms (e.g., the browser's back and forward buttons); otherwise, false.
+  1. Let |isCrossDocument| be true if <var ignore>specified browsing context</var>'s [=active document=] is different from <var ignore>specified entry</var>'s [=session history entry/document=]; otherwise, false.
+  1. Let |continue| be the result of [=firing a navigate event=] at |appHistory| given <var ignore>url</var>, with <i>[=fire a navigate event/isPush=]</i> set to false, <i>[=fire a navigate event/isBackForward=]</i> set to true, <i>[=fire a navigate event/isCrossDocument=]</i> set to |isCrossDocument|, and <i>[=fire a navigate event/isBrowserUI=]</i> and <i>[=fire a navigate event/isUserInitiated=]</i> both set to |isBrowserUI|.
+  1. If |continue| is false, abort these steps.
+</div>


### PR DESCRIPTION
@natechapin this should hopefully help. (Check out the preview link that _should_ be auto-generated.) It's a bit more complex than your implementation because I want to preserve any pushState() or replaceState() arguments, and it tries to incorporate all the stuff that you're deferring for now.

<del>I don't yet have the monkeypatches that fire the event, so the "fire an event" algorithm might not be quite right. But I think I captured all the inputs. (There are a lot of them... maybe some can be collapsed, once we see the call sites.)</del>


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/app-history/pull/63.html" title="Last updated on Mar 11, 2021, 7:09 PM UTC (1b9c6b2)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/app-history/63/4cf5cd7...1b9c6b2.html" title="Last updated on Mar 11, 2021, 7:09 PM UTC (1b9c6b2)">Diff</a>