### PR TITLE
Re-do interrupted and aborted navigations

### DIFF
--- a/interception-details.md
+++ b/interception-details.md
@@ -6,7 +6,7 @@ TODO: research where in these sequences accessibility technology should integrat
 
 ## Same-document
 
-### Immediate successful `respondWith()`
+### Immediately-successful `respondWith()`
 
 ```js
 appHistory.addEventListener("navigate", e => {
@@ -136,7 +136,7 @@ After the promise rejects in ten seconds:
 
 1. `appHistory.current.finished` changes to `true`.
 1. `appHistory.current` fires `finish`.
-1. `navigateerror` is fired on `window.appHistory`.
+1. `navigateerror` is fired on `window.appHistory`, with the `new Error("bad")` exception.
 1. Any loading spinner UI stops.
 
 Note: any unreachable `AppHistoryEntry`s disposed as part of the synchronous block do not get resurrected.
@@ -183,15 +183,14 @@ Asynchronously but basically immediately:
 
 After one second:
 
-1. `navigateerror` fires on `window.appHistory`.
+1. `navigateerror` fires on `window.appHistory`, with an `"AbortError"` `DOMException`.
 1. `appHistory.current` fires `navigatefrom`.
 1. `location.href` updates to `"/bar"`.
 1. `appHistory.current` changes to a new `AppHistoryEntry` representing `/bar`. `appHistory.current.finished` is `false`.
 1. `currentchange` fires on `window.appHistory`.
 1. `appHistory.current` fires `navigateto`.
-1. The no-longer current `AppHistoryEntry` representing `/foo` fires `dispose`.
 1. The `event.signal` for the navigation to `/foo` fires an `"abort"` event.
-1. Any loading spinner UI stops.
+1. Any loading spinner UI stops, but then restarts. (Or maybe it never stops.)
 1. The second `console.log()` outputs `"/bar"`.
 
 After ten seconds:
@@ -203,6 +202,69 @@ After eleven seconds:
 
 1. The `setTimeout()` promise inside the navigation to `/bar` fulfills.
 1. Since `e.signal.aborted` is `false`, the code inside the `navigate` handler updates `document.body.innerHTML`.
+1. `appHistory.current.finished` changes to `true`.
+1. `appHistory.current` fires `finish`.
+1. `navigatesuccess` is fired on `appHistory`.
+1. Any loading spinner UI stops.
+
+### Trying to interrupt a slow navigation, but the `navigate` handler doesn't care
+
+This is a modification of the above example where the web developer does not pay attention to the `signal` property of the event. It shows exactly what goes wrong in that case. Changes are **bolded**.
+
+```js
+appHistory.addEventListener("navigate", e => {
+  e.respondWith((async () => {
+    await new Promise(r => setTimeout(r, 10_000));
+    document.body.innerHTML = `navigated to ${e.destination.url}`;
+  })());
+});
+
+location.href = "/foo";
+console.log(location.href);
+
+setTimeout(() => {
+  location.href = "/bar";
+  console.log(location.href);
+}, 1_000);
+```
+
+Synchronously:
+
+1. `navigate` fires on `window.appHistory`.
+1. `appHistory.current` fires `navigatefrom`.
+1. `location.href` updates to `"/foo"`.
+1. `appHistory.current` updates to a new `AppHistoryEntry` representing `/foo`. `appHistory.current.finished` is `false`.
+1. `currentchange` fires on `window.appHistory`.
+1. `appHistory.current` fires `navigateto`.
+1. Any now-unreachable `AppHistoryEntry` instances fire `dispose`.
+1. The `console.log()` outputs `"/foo"`.
+
+Asynchronously but basically immediately:
+
+1. The URL bar updates to show `/foo`.
+1. Any loading spinner UI starts.
+
+After one second:
+
+1. `navigateerror` fires on `window.appHistory`, with an `"AbortError"` `DOMException`.
+1. `appHistory.current` fires `navigatefrom`.
+1. `location.href` updates to `"/bar"`.
+1. `appHistory.current` changes to a new `AppHistoryEntry` representing `/bar`. `appHistory.current.finished` is `false`.
+1. `currentchange` fires on `window.appHistory`.
+1. `appHistory.current` fires `navigateto`.
+1. The `event.signal` for the navigation to `/foo` fires an `"abort"` event. (But nobody is listening to it.)
+1. Any loading spinner UI stops, but then restarts. (Or maybe it never stops.)
+1. The second `console.log()` outputs `"/bar"`.
+
+After ten seconds:
+
+1. The `setTimeout()` promise inside the original navigation to `/foo` fulfills.
+1. **The code inside the `navigate` handler updates the body to `"navigated to /foo"`. (Note that this mismatches `location.href`!)**
+
+After eleven seconds:
+
+1. The `setTimeout()` promise inside the navigation to `/bar` fulfills.
+1. The code inside the `navigate` handler updates the body to `"navigated to /bar"`. (Now it matches `location.href` again.)
 1. `appHistory.current.finished` changes to `true`.
 1. `appHistory.current` fires `finish`.
 1. `navigatesuccess` is fired on `appHistory`.


### PR DESCRIPTION
Closes #38 by making it explicit that the stop button is meant to trigger the navigate event's AbortSignal.

Closes #10 by getting rid of queued-up navigations, their associated event, and their associated callback variants to update() and push(). Instead, navigations during other navigations interrupt the ongoing one. As the new example tries to show, this seems to work pretty well.

Closes #13 by canceling all pending navigations when another one starts, of which the case discussed there is one example.

This does not yet solve #11; I will comment over there momentarily.

/cc @esprehn; I'd love you to take a look if you have time, since this tries to address some of the issues you found with our current setup. Also @tbondwilkinson since it was him and I who originally brainstormed the queuing system that this largely discards.