### PR TITLE
Fire navigatesuccess/navigateerror even without respondWith()

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -219,6 +219,8 @@ The <dfn attribute for="AppHistoryNavigateEvent">canRespond</dfn>, <dfn attribut
 
 An {{AppHistoryNavigateEvent}} has an associated [=URL=] <dfn for="AppHistoryNavigateEvent">destination URL</dfn>, an associated boolean <dfn for="AppHistoryNavigateEvent">is push</dfn>, and an associated [=serialized state=]-or-null <dfn for="AppHistoryNavigateEvent">classic history API serialized data</dfn>. All of these are set when the event is [=fire a navigate event|fired=].
 
+An {{AppHistoryNavigateEvent}} also has an associated {{Promise}}-or-null <dfn for="AppHistoryNavigateEvent">navigation action promise</dfn>, initially null.
+
 <div algorithm>
   The <dfn method for="AppHistoryNavigateEvent">respondWith(|newNavigationAction|)</dfn> method steps are:
 
@@ -227,12 +229,8 @@ An {{AppHistoryNavigateEvent}} has an associated [=URL=] <dfn for="AppHistoryNav
   1. If [=this=]'s [=Event/dispatch flag=] is unset, then throw an "{{InvalidStateError}}" {{DOMException}}.
   1. If [=this=]'s [=Event/canceled flag=] is set, then throw an "{{InvalidStateError}}" {{DOMException}}.
   1. Set [=this=]'s [=Event/canceled flag=].
+  1. Set [=this=]'s [=AppHistoryNavigateEvent/navigation action promise=] to |newNavigationAction|.
   1. Run the <a spec="HTML">URL and history update steps</a> given [=this=]'s [=relevant global object=]'s [=associated document=] and [=this=]'s [=AppHistoryNavigateEvent/destination URL=], with <i>[=URL and history update steps/serializedData=]</i> set to [=this=]'s [=AppHistoryNavigateEvent/classic history API serialized data=] and <i>[=URL and history update steps/isPush=]</i> set to [=this=]'s [=AppHistoryNavigateEvent/is push=].
-  1. Let |appHistory| be [=this=]'s [=relevant global object=]'s [=Window/app history=].
-  1. [=promise/React=] to |newNavigationAction| with the following fulfillment steps:
-      1. [=Fire an event=] named {{AppHistory/navigatesuccess}} at |appHistory|.
-    and the following rejection steps given reason |rejectionReason|:
-      1. [=Fire an event=] named {{AppHistory/navigateerror}} at |appHistory| using {{ErrorEvent}}, with {{ErrorEvent/error}} initialized to |rejectionReason|, and {{ErrorEvent/message}}, {{ErrorEvent/filename}}, {{ErrorEvent/lineno}}, and {{ErrorEvent/colno}} initialized to appropriate values that can be extracted from |rejectionReason| in the same underspecified way the user agent typically does for the <a spec="HTML">report an exception</a> algorithm.
 </div>
 
 <hr>
@@ -240,7 +238,8 @@ An {{AppHistoryNavigateEvent}} has an associated [=URL=] <dfn for="AppHistoryNav
 <div algorithm="fire a navigate event">
   To <dfn>fire a `navigate` event</dfn> at an {{AppHistory}} |appHistory| given a [=URL=] |destinationURL|, a boolean <dfn for="fire a navigate event">|isPush|</dfn>, a boolean <dfn for="fire a navigate event">|isSameDocument|</dfn>, an optional [=user navigation involvement=] <dfn for="fire a navigate event">|userInvolvement|</dfn> (default "<code>[=user navigation involvement/none=]</code>"), an optional boolean <dfn for="fire a navigate event">|isHistoryTraversal|</dfn> (default false), an optional value |navigateInfo| (default null), an optional [=list=] of [=FormData/entries=] or null <dfn for="fire a navigate event">|formDataEntryList|</dfn> (default null), and an optional [=serialized state=]-or-null <dfn for="fire a navigate event">|classicHistoryAPISerializedData|</dfn> (default null):
 
-  1. Let |event| be the result of [=creating an event=] given {{AppHistoryNavigateEvent}}, in the [=relevant Realm=] of |appHistory|.
+  1. Let |realm| be |appHistory|'s [=relevant Realm=].
+  1. Let |event| be the result of [=creating an event=] given {{AppHistoryNavigateEvent}}, in |realm|.
   1. Set |event|'s [=AppHistoryNavigateEvent/destination URL=] to |destinationURL|.
   1. Set |event|'s [=AppHistoryNavigateEvent/is push=] to |isPush|.
   1. Set |event|'s [=AppHistoryNavigateEvent/classic history API serialized data=] to |classicHistoryAPISerializedData|.
@@ -257,8 +256,17 @@ An {{AppHistoryNavigateEvent}} has an associated [=URL=] <dfn for="AppHistoryNav
   1. If |destinationURL| is [=rewritable=] relative to |currentURL|, and either |isSameDocument| is true or |isHistoryTraversal| is false, then initialize |event|'s {{AppHistoryNavigateEvent/canRespond}} to true. Otherwise, initialize it to false.
   1. If either |userInvolvement| is not "<code>[=user navigation involvement/browser UI=]</code>" or |isHistoryTraversal| is false, then initialize |event|'s {{Event/cancelable}} to true.
   1. If |userInvolvement| is "<code>[=user navigation involvement/none=]</code>", then initialize |event|'s {{AppHistoryNavigateEvent/userInitiated}} to false. Otherwise, initialize it to true.
-  1. If |formDataEntryList| is not null, then initialize |event|'s {{AppHistoryNavigateEvent/formData}} to a [=new=] {{FormData}} created in the [=relevant Realm=] of |appHistory|, associated to |formDataEntryList|. Otherwise, initialize it to null.
-  1. Return the result of [=dispatching=] |event| at |appHistory|.
+  1. If |formDataEntryList| is not null, then initialize |event|'s {{AppHistoryNavigateEvent/formData}} to a [=new=] {{FormData}} created in |realm|, associated to |formDataEntryList|. Otherwise, initialize it to null.
+  1. Let |result| be the result of [=dispatching=] |event| at |appHistory|.
+  1. If [=this=]'s [=relevant global object=]'s [=Window/browsing context=] is null, then return false.
+     <p class="note">This can occurr if an event listener disconnected the <{iframe}> corresponding to [=this=]'s [=relevant global object=].</p>
+  1. If |isSameDocument| is true, and either |event|'s [=AppHistoryNavigateEvent/navigation action promise=] is non-null or |result| is true, then:
+    1. If |event|'s [=AppHistoryNavigateEvent/navigation action promise=] is null, then set it to a [=a promise resolved with=] undefined, created in |realm|.
+    1. [=promise/React=] to |event|'s [=AppHistoryNavigateEvent/navigation action promise=] with the following fulfillment steps:
+        1. [=Fire an event=] named {{AppHistory/navigatesuccess}} at |appHistory|.
+      and the following rejection steps given reason |rejectionReason|:
+        1. [=Fire an event=] named {{AppHistory/navigateerror}} at |appHistory| using {{ErrorEvent}}, with {{ErrorEvent/error}} initialized to |rejectionReason|, and {{ErrorEvent/message}}, {{ErrorEvent/filename}}, {{ErrorEvent/lineno}}, and {{ErrorEvent/colno}} initialized to appropriate values that can be extracted from |rejectionReason| in the same underspecified way the user agent typically does for the <a spec="HTML">report an exception</a> algorithm.
+  1. Return |result|.
 </div>
 
 <!-- Remember to modify pushState()/replaceState() to use this, when we eventually move to the HTML Standard. -->

--- a/spec.bs
+++ b/spec.bs
@@ -260,12 +260,14 @@ An {{AppHistoryNavigateEvent}} also has an associated {{Promise}}-or-null <dfn f
   1. Let |result| be the result of [=dispatching=] |event| at |appHistory|.
   1. If [=this=]'s [=relevant global object=]'s [=Window/browsing context=] is null, then return false.
      <p class="note">This can occurr if an event listener disconnected the <{iframe}> corresponding to [=this=]'s [=relevant global object=].</p>
-  1. If |isSameDocument| is true, and either |event|'s [=AppHistoryNavigateEvent/navigation action promise=] is non-null or |result| is true, then:
+  1. If |event|'s [=AppHistoryNavigateEvent/navigation action promise=] is non-null, or both |result| and |isSameDocument| are true, then:
     1. If |event|'s [=AppHistoryNavigateEvent/navigation action promise=] is null, then set it to a [=a promise resolved with=] undefined, created in |realm|.
     1. [=promise/React=] to |event|'s [=AppHistoryNavigateEvent/navigation action promise=] with the following fulfillment steps:
         1. [=Fire an event=] named {{AppHistory/navigatesuccess}} at |appHistory|.
       and the following rejection steps given reason |rejectionReason|:
         1. [=Fire an event=] named {{AppHistory/navigateerror}} at |appHistory| using {{ErrorEvent}}, with {{ErrorEvent/error}} initialized to |rejectionReason|, and {{ErrorEvent/message}}, {{ErrorEvent/filename}}, {{ErrorEvent/lineno}}, and {{ErrorEvent/colno}} initialized to appropriate values that can be extracted from |rejectionReason| in the same underspecified way the user agent typically does for the <a spec="HTML">report an exception</a> algorithm.
+
+    <p class="note">If |event|'s [=AppHistoryNavigateEvent/navigation action promise=] is non-null, then {{AppHistoryNavigateEvent/respondWith()}} was called and so we're performing a same-document navigation, for which we want to fire {{AppHistory/navigatesuccess}} or {{AppHistory/navigateerror}} events as appropriate. Otherwise, if the navigation is same-document and was not canceled, we still fire {{AppHistory/navigatesuccess}} after a microtask.
   1. Return |result|.
 </div>
 


### PR DESCRIPTION
Follows the implementation in https://chromium-review.googlesource.com/c/chromium/src/+/2786205.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/app-history/pull/87.html" title="Last updated on Mar 30, 2021, 8:51 PM UTC (b49dfa3)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/app-history/87/44c51c1...b49dfa3.html" title="Last updated on Mar 30, 2021, 8:51 PM UTC (b49dfa3)">Diff</a>