### PR TITLE
Minor fixups to getState() and navigation cancelation

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ Crucially, `appHistory.current` stays the same regardless of what iframe navigat
 
 - Via the same-document navigation API `history.pushState()`. (Not `history.replaceState()`.)
 
-- A full-page navigation to a different document. This could be an existing document in the browser's back/forward cache, or a new document. In the latter case, this will generate a new entry on the new page's `window.appHistory` object, somewhat similar to `appHistory.navigate(navigatedToURL, { state: null })`. Note that if the navigation is cross-origin, then we'll end up in a separate app history list for that other origin.
+- A full-page navigation to a different document. This could be an existing document in the browser's back/forward cache, or a new document. In the latter case, this will generate a new entry on the new page's `window.appHistory` object, somewhat similar to `appHistory.navigate(navigatedToURL, { state: undefined })`. Note that if the navigation is cross-origin, then we'll end up in a separate app history list for that other origin.
 
 - When using the `navigate` event to [convert a cross-document non-replace navigation into a same-document navigation](#navigation-monitoring-and-interception).
 
@@ -597,7 +597,7 @@ In a single-page app using the app history API, instead the router listens to th
 There's one gap remaining, which is the ability to send additional state or info along with a navigation. We solve this by introducing a new API, `appHistory.navigate()`, which can be thought of as an augmented and combined version of `location.assign()` and `location.replace()`. The non-replace usage of `appHistory.navigate()` is as follows:
 
 ```js
-// Navigate to a new URL, resetting the state to null:
+// Navigate to a new URL, resetting the state to undefined:
 // (equivalent to `location.assign(url)`)
 await appHistory.navigate(url);
 

--- a/spec.bs
+++ b/spec.bs
@@ -681,6 +681,7 @@ The <dfn attribute for="AppHistoryDestination">sameDocument</dfn> getter steps a
   1. If |appHistory|'s [=AppHistory/ongoing navigate event=] is non-null, then:
     1. Set |appHistory|'s [=AppHistory/ongoing navigate event=]'s [=Event/canceled flag=] to true.
     1. Set |appHistory|'s [=AppHistory/ongoing navigate event=]'s [=AppHistoryNavigateEvent/navigation action promise=] to null.
+    1. Set |appHistory|'s [=AppHistory/ongoing navigate event=] to null.
 </div>
 
 <!-- Remember to modify pushState()/replaceState() to use this, when we eventually move to the HTML Standard. -->
@@ -794,8 +795,8 @@ Each {{AppHistoryEntry}} has an associated <dfn for="AppHistoryEntry">index</dfn
 <div algorithm>
   The <dfn method for="AppHistoryEntry">getState()</dfn> method steps are:
 
-  1. If [=this=]'s [=relevant global object=]'s [=associated Document=] is not [=Document/fully active=], then return null.
-  1. If [=this=]'s [=AppHistoryEntry/session history entry=]'s [=session history entry/app history state=] is null, then return null.
+  1. If [=this=]'s [=relevant global object=]'s [=associated Document=] is not [=Document/fully active=], then return undefined.
+  1. If [=this=]'s [=AppHistoryEntry/session history entry=]'s [=session history entry/app history state=] is null, then return undefined.
   1. Return [$StructuredDeserialize$]([=this=]'s [=AppHistoryEntry/session history entry=]'s [=session history entry/app history state=]).
 
   <p class="note">Unlike {{History/state|history.state}}, this will deserialize upon each access.


### PR DESCRIPTION
In particular:

* Use undefined instead of null to represent no state stored.

* Clean up the ongoing navigate event once it's been canceled.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/app-history/pull/106.html" title="Last updated on May 5, 2021, 5:58 PM UTC (20574dd)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/app-history/106/99ac021...20574dd.html" title="Last updated on May 5, 2021, 5:58 PM UTC (20574dd)">Diff</a>