### PR TITLE
Remove unnecessary save/restore of state in navigate()

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -382,8 +382,6 @@ Each {{AppHistory}} object has an associated <dfn for="AppHistory">navigate meth
 
   1. Let |previousPromise| be |appHistory|'s [=AppHistory/navigate method call promise=].
 
-  1. Let |previousState| be |appHistory|'s [=AppHistory/navigate method call serialized state=].
-
   1. Set |appHistory|'s [=AppHistory/navigate method call promise=] to |promise|.
 
   1. Set |appHistory|'s [=AppHistory/navigate method call serialized state=] to |serializedState|.
@@ -392,9 +390,9 @@ Each {{AppHistory}} object has an associated <dfn for="AppHistory">navigate meth
 
   1. If [=AppHistory/navigate method call serialized state=] is non-null, then set |browsingContext|'s [=session history=]'s [=session history/current entry=]'s [=session history entry/app history state=] to |appHistory|'s [=AppHistory/navigate method call serialized state=].
 
-  1. Set |appHistory|'s [=AppHistory/navigate method call promise=] to |previousPromise|.
+  1. Set |appHistory|'s [=AppHistory/navigate method call serialized state=] to null.
 
-  1. Set |appHistory|'s [=AppHistory/navigate method call serialized state=] to |previousState|.
+  1. Set |appHistory|'s [=AppHistory/navigate method call promise=] to |previousPromise|.
 
   1. Return |promise|.
 </div>


### PR DESCRIPTION
Discovered during implementation in https://chromium-review.googlesource.com/c/chromium/src/+/2842506.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/app-history/pull/107.html" title="Last updated on May 7, 2021, 4:42 PM UTC (2efb132)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/app-history/107/639249f...2efb132.html" title="Last updated on May 7, 2021, 4:42 PM UTC (2efb132)">Diff</a>