### PR TITLE
Bail out of navigate() on non-fully-active documents

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -532,7 +532,7 @@ An {{AppHistoryNavigateEvent}} also has an associated {{Promise}}-or-null <dfn f
 <div algorithm>
   The <dfn method for="AppHistoryNavigateEvent">respondWith(|newNavigationAction|)</dfn> method steps are:
 
-  1. If [=this=]'s [=relevant global object=]'s [=Window/browsing context=] is null, then throw an "{{InvalidStateError}}" {{DOMException}}.
+  1. If [=this=]'s [=relevant global object=]'s [=active Document=] is not [=Document/fully active=], then throw an "{{InvalidStateError}}" {{DOMException}}.
   1. If [=this=]'s {{Event/isTrusted}} attribute was initialized to false, then throw a "{{SecurityError}}" {{DOMException}}.
   1. If [=this=]'s {{AppHistoryNavigateEvent/canRespond}} attribute was initialized to false, then throw a "{{SecurityError}}" {{DOMException}}.
   1. If [=this=]'s [=Event/dispatch flag=] is unset, then throw an "{{InvalidStateError}}" {{DOMException}}.
@@ -637,7 +637,7 @@ The <dfn attribute for="AppHistoryDestination">sameDocument</dfn> getter steps a
   1. Set |appHistory|'s [=AppHistory/ongoing navigate event=] to |event|.
   1. Let |result| be the result of [=dispatching=] |event| at |appHistory|.
   1. Set |appHistory|'s [=AppHistory/ongoing navigate event=] to null.
-  1. If |appHistory|'s [=relevant global object=]'s [=Window/browsing context=] is null, then return false.
+  1. If |appHistory|'s [=relevant global object=]'s [=active Document=] is not [=Document/fully active=], then return false.
     1. [=Signal an aborted navigation=] for |appHistory|.
     1. Return false.
 

--- a/spec.bs
+++ b/spec.bs
@@ -235,7 +235,7 @@ Each {{AppHistory}} object has an associated <dfn for="AppHistory">navigate meth
 <div algorithm>
   To <dfn for="AppHistory">update the entries</dfn> for an {{AppHistory}} instance |appHistory|:
 
-  1. Let |browsingContext| be |appHistory|'s [=relevant global object=]'s [=associated Document=]'s [=Document/browsing context=].
+  1. Let |browsingContext| be |appHistory|'s [=relevant global object=]'s [=Window/browsing context=].
 
   1. [=Assert=]: |browsingContext| is not null.
 
@@ -368,7 +368,11 @@ Each {{AppHistory}} object has an associated <dfn for="AppHistory">navigate meth
 <div algorithm>
   To <dfn>perform an app history navigation</dfn> given an {{AppHistory}} object |appHistory|, a [=URL=] |url|, and an {{AppHistoryNavigateOptions}} |options|:
 
+  1. If |appHistory|'s [=relevant global object=]'s [=associated Document=] is not [=Document/fully active=], then return [=a promise rejected with=] an "{{InvalidStateError}}" {{DOMException}}.
+
   1. Let |browsingContext| be |appHistory|'s [=relevant global object=]'s [=Window/browsing context=].
+
+  1. [=Assert=]: |browsingContext| is not null.
 
   1. Let |historyHandling| be "<a for="history handling behavior">`replace`</a>" if |options|["{{AppHistoryNavigateOptions/replace}}"] [=map/exists=] and is true; otherwise, "<a for="history handling behavior">`default`</a>".
 


### PR DESCRIPTION
Similar to https://chromium-review.googlesource.com/c/chromium/src/+/2880835.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/app-history/pull/108.html" title="Last updated on May 7, 2021, 7:14 PM UTC (09d1327)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/app-history/108/d2ffe88...09d1327.html" title="Last updated on May 7, 2021, 7:14 PM UTC (09d1327)">Diff</a>