### PR TITLE
Remove misleading spec note about same-document navigations

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -313,8 +313,6 @@ Each {{AppHistory}} object has an associated <dfn for="AppHistory">navigate meth
   1. Set |appHistory|'s [=AppHistory/entry list=] to |newEntryList|.
 
   1. Set |appHistory|'s [=AppHistory/current index=] to |newCurrentIndex|.
-
-  <p class="note">For same-document navigations only the [=AppHistory/current index=] and the [=AppHistoryEntry/index|indices=] of the various {{AppHistoryEntry}} objects will ultimately be updated by this algorithm. Implementations can special-case same-document navigations and avoid reassembling the [=AppHistory/entry list=].
 </div>
 
 <h3 id="global-navigate">Navigating</h3>


### PR DESCRIPTION
For replacements, at least, appHistory.current will change object identity.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/app-history/pull/123.html" title="Last updated on May 27, 2021, 10:06 PM UTC (e8e0764)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/app-history/123/eae73ce...e8e0764.html" title="Last updated on May 27, 2021, 10:06 PM UTC (e8e0764)">Diff</a>