### PR TITLE
Introduce performance timeline API integration

### DIFF
--- a/interception-details.md
+++ b/interception-details.md
@@ -23,7 +23,6 @@ Synchronously:
 1. `appHistory.current` fires `navigatefrom`.
 1. `location.href` updates.
 1. `appHistory.current` and `appHistory.transition` update.
-1. `currentchange` fires on `window.appHistory`.
 1. `appHistory.current` fires `navigateto`.
 1. Any now-unreachable `AppHistoryEntry` instances fire `dispose`.
 1. The `console.log()` outputs `"#foo"`
@@ -90,7 +89,6 @@ Synchronously:
 1. `appHistory.current` fires `navigatefrom`.
 1. `location.href` updates.
 1. `appHistory.current` and `appHistory.transition` update.
-1. `currentchange` fires on `window.appHistory`.
 1. `appHistory.current` fires `navigateto`.
 1. Any now-unreachable `AppHistoryEntry` instances fire `dispose`.
 1. The `console.log()` outputs `"/foo"`.
@@ -126,7 +124,6 @@ Synchronously:
 1. `appHistory.current` fires `navigatefrom`.
 1. `location.href` updates.
 1. `appHistory.current` and `appHistory.transition` update.
-1. `currentchange` fires on `window.appHistory`.
 1. `appHistory.current` fires `navigateto`.
 1. Any now-unreachable `AppHistoryEntry` instances fire `dispose`.
 1. The `console.log()` outputs `"/foo"`.
@@ -177,7 +174,6 @@ Synchronously:
 1. `appHistory.current` fires `navigatefrom`.
 1. `location.href` updates to `"/foo"`.
 1. `appHistory.current` updates to a new `AppHistoryEntry` representing `/foo`, and `appHistory.transition` updates to represent the transition from the starting URL to `/foo`.
-1. `currentchange` fires on `window.appHistory`.
 1. `appHistory.current` fires `navigateto`.
 1. Any now-unreachable `AppHistoryEntry` instances fire `dispose`.
 1. The `console.log()` outputs `"/foo"`.
@@ -196,7 +192,6 @@ After one second:
 1. `appHistory.current` fires `navigatefrom`.
 1. `location.href` updates to `"/bar"`.
 1. `appHistory.current` changes to a new `AppHistoryEntry` representing `/bar`, and `appHistory.transition` updates to represent the transition from `/foo` to `/bar` (_not_ from the starting URL to `/bar`).
-1. `currentchange` fires on `window.appHistory`.
 1. `appHistory.current` fires `navigateto`.
 1. Any loading spinner UI stops, but then restarts. (Or maybe it never stops.)
 1. The second `console.log()` outputs `"/bar"`.
@@ -244,7 +239,6 @@ Synchronously:
 1. `appHistory.current` fires `navigatefrom`.
 1. `location.href` updates to `"/foo"`.
 1. `appHistory.current` updates to a new `AppHistoryEntry` representing `/foo`, and `appHistory.transition` updates to represent the transition from the starting URL to `/foo`.
-1. `currentchange` fires on `window.appHistory`.
 1. `appHistory.current` fires `navigateto`.
 1. Any now-unreachable `AppHistoryEntry` instances fire `dispose`.
 1. The `console.log()` outputs `"/foo"`.
@@ -263,7 +257,6 @@ After one second:
 1. `appHistory.current` fires `navigatefrom`.
 1. `location.href` updates to `"/bar"`.
 1. `appHistory.current` changes to a new `AppHistoryEntry` representing `/bar`, and `appHistory.transition` updates to represent the transition from `/foo` to `/bar` (_not_ from the starting URL to `/bar`).
-1. `currentchange` fires on `window.appHistory`.
 1. `appHistory.current` fires `navigateto`.
 1. Any loading spinner UI stops, but then restarts. (Or maybe it never stops.)
 1. The second `console.log()` outputs `"/bar"`.

--- a/interception-details.md
+++ b/interception-details.md
@@ -38,6 +38,7 @@ After the promise settles in one microtask:
 1. `navigatesuccess` is fired on `appHistory`.
 1. `appHistory.transition.finished` fulfills.
 1. `appHistory.transition` updates back to null.
+1. A new `SameDocumentNavigationEntry` indicating success is [queued](https://w3c.github.io/performance-timeline/#queue-a-performanceentry), with a short (but nonzero) duration.
 
 ### No interception
 
@@ -50,7 +51,7 @@ location.hash = "#foo";
 console.log(location.hash);
 ```
 
-This is the same as the previous case.
+This is the same as the previous case, except that the `SameDocumentNavigationEntry` has zero duration.
 
 ### Cancelation
 
@@ -106,6 +107,7 @@ After the promise fulfills in ten seconds:
 1. `appHistory.transition.finished` fulfills.
 1. `appHistory.transition` updates back to null.
 1. Any loading spinner UI stops.
+1. A new `SameDocumentNavigationEntry` indicating success is [queued](https://w3c.github.io/performance-timeline/#queue-a-performanceentry), with a ten-second duration.
 
 ### Delayed failure
 
@@ -141,6 +143,7 @@ After the promise rejects in ten seconds:
 1. `appHistory.transition.finished` rejects, with the `new Error("bad")` exception.
 1. `appHistory.transition` updates back to null.
 1. Any loading spinner UI stops.
+1. A new `SameDocumentNavigationEntry` indicating failure is [queued](https://w3c.github.io/performance-timeline/#queue-a-performanceentry), with a ten-second duration.
 
 Note: any unreachable `AppHistoryEntry`s disposed as part of the synchronous block do not get resurrected.
 
@@ -188,12 +191,13 @@ After one second:
 
 1. `navigateerror` fires on `window.appHistory`, with an `"AbortError"` `DOMException`.
 1. `appHistory.transition.finished` rejects with that `"AbortError"` `DOMException`.
+1. The `event.signal` for the navigation to `/foo` fires an `"abort"` event.
+1. A new `SameDocumentNavigationEntry` indicating failure is [queued](https://w3c.github.io/performance-timeline/#queue-a-performanceentry), with a one-second duration.
 1. `appHistory.current` fires `navigatefrom`.
 1. `location.href` updates to `"/bar"`.
 1. `appHistory.current` changes to a new `AppHistoryEntry` representing `/bar`, and `appHistory.transition` updates to represent the transition from `/foo` to `/bar` (_not_ from the starting URL to `/bar`).
 1. `currentchange` fires on `window.appHistory`.
 1. `appHistory.current` fires `navigateto`.
-1. The `event.signal` for the navigation to `/foo` fires an `"abort"` event.
 1. Any loading spinner UI stops, but then restarts. (Or maybe it never stops.)
 1. The second `console.log()` outputs `"/bar"`.
 
@@ -211,6 +215,7 @@ After eleven seconds:
 1. `appHistory.transition.finished` fulfills.
 1. `appHistory.transition` updates back to null.
 1. Any loading spinner UI stops.
+1. A new `SameDocumentNavigationEntry` indicating success is [queued](https://w3c.github.io/performance-timeline/#queue-a-performanceentry), with a ten-second duration.
 
 ### Trying to interrupt a slow navigation, but the `navigate` handler doesn't care
 
@@ -252,12 +257,14 @@ Asynchronously but basically immediately:
 After one second:
 
 1. `navigateerror` fires on `window.appHistory`, with an `"AbortError"` `DOMException`.
+1. `appHistory.transition.finished` rejects with that `"AbortError"` `DOMException`.
+1. The `event.signal` for the navigation to `/foo` fires an `"abort"` event. (But nobody is listening to it.)
+1. A new `SameDocumentNavigationEntry` indicating failure is [queued](https://w3c.github.io/performance-timeline/#queue-a-performanceentry), with a one-second duration.
 1. `appHistory.current` fires `navigatefrom`.
 1. `location.href` updates to `"/bar"`.
 1. `appHistory.current` changes to a new `AppHistoryEntry` representing `/bar`, and `appHistory.transition` updates to represent the transition from `/foo` to `/bar` (_not_ from the starting URL to `/bar`).
 1. `currentchange` fires on `window.appHistory`.
 1. `appHistory.current` fires `navigateto`.
-1. The `event.signal` for the navigation to `/foo` fires an `"abort"` event. (But nobody is listening to it.)
 1. Any loading spinner UI stops, but then restarts. (Or maybe it never stops.)
 1. The second `console.log()` outputs `"/bar"`.
 
@@ -275,3 +282,4 @@ After eleven seconds:
 1. `appHistory.transition.finished` fulfills.
 1. `appHistory.transition` updates back to null.
 1. Any loading spinner UI stops.
+1. A new `SameDocumentNavigationEntry` indicating success is [queued](https://w3c.github.io/performance-timeline/#queue-a-performanceentry), with a ten-second duration.


### PR DESCRIPTION
This replaces our previous broken idea of using `currentchange` for this. Closes #59. Closes #33. #14 remains to track whether `currentchange` is actually useful.

The main question is, what information should be included here, beyond the basics of URL/start time/duration? So far I added `success`, but I'm not sure whether that's useful. Other ideas include `navigationType`, `navigateInfo`, `userInitiated`, and `referrer` (or some other name for the previous URL).

See also https://github.com/WICG/app-history/issues/124 since I think interrupted navigations counting as failures would be pretty noisy to send to an analytics provider unless we also fix that.

@yoavweiss, I'd love your thoughts on this!