### PR TITLE
add event map to AppHistory, for types of Event

### DIFF
--- a/app_history.d.ts
+++ b/app_history.d.ts
@@ -4,6 +4,7 @@ interface Window {
 
 interface AppHistoryEventMap {
   "navigate": AppHistoryNavigateEvent;
+  "navigatesuccess": Event;
   "navigateerror": ErrorEvent;
 }
 
@@ -41,6 +42,13 @@ declare class AppHistoryTransition {
   rollback(options?: AppHistoryNavigationOptions): Promise<void>;
 }
 
+interface AppHistoryEntryEventMap {
+  "navigateto": Event;
+  "navigatefrom": Event;
+  "finish": Event;
+  "dispose": Event;
+}
+
 declare class AppHistoryEntry extends EventTarget {
   readonly key: string;
   readonly id: string;
@@ -54,6 +62,11 @@ declare class AppHistoryEntry extends EventTarget {
   onnavigatefrom: ((this: AppHistoryEntry, ev: Event) => any)|null;
   onfinish: ((this: AppHistoryEntry, ev: Event) => any)|null;
   ondispose: ((this: AppHistoryEntry, ev: Event) => any)|null;
+
+  addEventListener<K extends keyof AppHistoryEntryEventMap>(type: K, listener: (this: AppHistory, ev: AppHistoryEntryEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+  addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
+  removeEventListener<K extends keyof AppHistoryEntryEventMap>(type: K, listener: (this: AppHistory, ev: AppHistoryEntryEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+  removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
 }
 
 type AppHistoryNavigationType = 'reload'|'push'|'replace'|'traverse';

--- a/app_history.d.ts
+++ b/app_history.d.ts
@@ -2,6 +2,11 @@ interface Window {
   readonly appHistory: AppHistory;
 }
 
+interface AppHistoryEventMap {
+  "navigate": AppHistoryNavigateEvent;
+  "navigateerror": ErrorEvent;
+}
+
 declare class AppHistory extends EventTarget {
   readonly current: AppHistoryEntry|null;
   readonly transition: AppHistoryTransition|null;
@@ -21,6 +26,11 @@ declare class AppHistory extends EventTarget {
   onnavigate: ((this: AppHistory, ev: AppHistoryNavigateEvent) => any)|null;
   onnavigatesuccess: ((this: AppHistory, ev: Event) => any)|null;
   onnavigateerror: ((this: AppHistory, ev: ErrorEvent) => any)|null;
+
+  addEventListener<K extends keyof AppHistoryEventMap>(type: K, listener: (this: AppHistory, ev: AppHistoryEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+  addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
+  removeEventListener<K extends keyof AppHistoryEventMap>(type: K, listener: (this: AppHistory, ev: AppHistoryEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+  removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
 }
 
 declare class AppHistoryTransition {


### PR DESCRIPTION
This will give types when writing code like:

```js
window.appHistory.addEventListener('navigate', (event) => {
  // "event" is known by TS to be of type AppHistoryNavigateEvent
});
```