### PR TITLE
Rename navigateInfo to info

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ for (const entry of performance.getEntriesByType("same-document-navigation")) {
     - [Example: single-page app redirects and guards](#example-single-page-app-redirects-and-guards)
     - [Example: cross-origin affiliate links](#example-cross-origin-affiliate-links)
   - [New navigation API](#new-navigation-api)
-    - [Example: using `navigateInfo`](#example-using-navigateinfo)
+    - [Example: using `info`](#example-using-info)
     - [Example: next/previous buttons](#example-nextprevious-buttons)
   - [Per-entry events](#per-entry-events)
   - [Current entry change monitoring](#current-entry-change-monitoring)
@@ -307,7 +307,7 @@ The event object has several useful properties:
 
 - `formData`: a [`FormData`](https://developer.mozilla.org/en-US/docs/Web/API/FormData) object containing form submission data, or `null` if the navigation is not a form submission.
 
-- `info`: any value passed by `appHistory.navigate(url, { state, navigateInfo })`, `appHistory.back({ navigateInfo })`, or similar, if the navigation was initiated by one of those methods and the `navigateInfo` option was supplied. Otherwise, null. See [the example below](#example-using-navigateinfo) for more.
+- `info`: any value passed by `appHistory.navigate(url, { state, info })`, `appHistory.back({ info })`, or similar, if the navigation was initiated by one of those methods and the `info` option was supplied. Otherwise, undefined. See [the example below](#example-using-info) for more.
 
 - `signal`: an [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal) which can be monitored for when the navigation gets aborted.
 
@@ -635,8 +635,8 @@ await appHistory.navigate(url);
 // Use a new URL and state.
 await appHistory.navigate(url, { state });
 
-// You can also pass navigateInfo for the navigate event handler to receive:
-await appHistory.navigate(url, { state, navigateInfo });
+// You can also pass info for the navigate event handler to receive:
+await appHistory.navigate(url, { state, info });
 ```
 
 Note how unlike `history.pushState()`, `appHistory.navigate()` will by default perform a full navigation, e.g. scrolling to a fragment or navigating across documents. Single-page apps will usually intercept these using the `navigate` event, and convert them into same-document navigations by using `event.respondWith()`.
@@ -654,30 +654,30 @@ await appHistory.navigate(url, { replace: true });
 // Replace the URL and state at the same time.
 await appHistory.navigate(url, { replace: true, state });
 
-// You can still pass along navigateInfo:
-await appHistory.navigate(url, { replace: true, state, navigateInfo });
+// You can still pass along info:
+await appHistory.navigate(url, { replace: true, state, info });
 ```
 
 Again, unlike `history.replaceState()`, `appHistory.navigate(url, { replace: true })` will by default perform a full navigation. And again, single-page apps will usually intercept these using `navigate`.
 
-Finally, we have `appHistory.reload()`. This can be used as a replacement for `location.reload()`, but it also allows passing `navigateInfo` and `state`, which are useful when a single-page app intercepts the reload using the `navigate` event:
+Finally, we have `appHistory.reload()`. This can be used as a replacement for `location.reload()`, but it also allows passing `info` and `state`, which are useful when a single-page app intercepts the reload using the `navigate` event:
 
 ```js
 // Just like location.reload().
 await appHistory.reload();
 
-// Leave the state as-is, but pass some navigateInfo.
-await appHistory.reload({ navigateInfo });
+// Leave the state as-is, but pass some info.
+await appHistory.reload({ info });
 
 // Overwrite the state with a new value.
-await appHistory.reload({ state, navigateInfo });
+await appHistory.reload({ state, info });
 ```
 
 Note that both of these methods return promises. In the event that the navigations get converted into same-document navigations via `event.respondWith(promise)` in a `navigate` handler, these returned promises will settle in the same way that `promise` does. This gives your navigation call site an indication of the navigation's success or failure. (If they are non-intercepted fragment navigations, then the promises will fulfill immediately. And if they are non-intercepted cross-document navigations, then the returned promise, along with the entire JavaScript global environment, will disappear as the current document gets unloaded.)
 
-#### Example: using `navigateInfo`
+#### Example: using `info`
 
-The `navigateInfo` option to `appHistory.navigate()` gets passed to the `navigate` event handler as the `event.info` property. The intended use of this value is to convey transient information about this particular navigation, such as how it happened. In this way, it's different from the persisted value retrievable using `event.destination.getState()`.
+The `info` option to `appHistory.navigate()` gets passed to the `navigate` event handler as the `event.info` property. The intended use of this value is to convey transient information about this particular navigation, such as how it happened. In this way, it's different from the persisted value retrievable using `event.destination.getState()`.
 
 One example of how this might be used is to trigger different single-page navigation renderings depending on how a certain route was reached. For example, consider a photo gallery app, where you can reach the same photo URL and state via various routes:
 
@@ -690,16 +690,16 @@ Each of these wants a different animation at navigate time. This information doe
 ```js
 document.addEventListener("keydown", async e => {
   if (e.key === "ArrowLeft" && hasPreviousPhoto()) {
-    await appHistory.navigate(getPreviousPhotoURL(), { navigateInfo: { via: "go-left" } });
+    await appHistory.navigate(getPreviousPhotoURL(), { info: { via: "go-left" } });
   }
   if (e.key === "ArrowRight" && hasNextPhoto()) {
-    await appHistory.navigate(getNextPhotoURL(), { navigateInfo: { via: "go-right" } });
+    await appHistory.navigate(getNextPhotoURL(), { info: { via: "go-right" } });
   }
 });
 
 photoGallery.addEventListener("click", async e => {
   if (e.target.closest(".photo-thumbnail")) {
-    await appHistory.navigate(getPhotoURL(e.target), { navigateInfo: { via: "gallery", thumbnail: e.target } });
+    await appHistory.navigate(getPhotoURL(e.target), { info: { via: "gallery", thumbnail: e.target } });
   }
 });
 
@@ -727,7 +727,7 @@ appHistory.addEventListener("navigate", e => {
 });
 ```
 
-Note that in addition to `appHistory.navigate()`, the previously-discussed `appHistory.reload()`, `appHistory.back()`, `appHistory.forward()`, `appHistory.goTo()`, and `appHistory.transition.rollback()` methods can also take a `navigateInfo` option.
+Note that in addition to `appHistory.navigate()`, the previously-discussed `appHistory.reload()`, `appHistory.back()`, `appHistory.forward()`, `appHistory.goTo()`, and `appHistory.transition.rollback()` methods can also take a `info` option.
 
 #### Example: next/previous buttons
 
@@ -1379,7 +1379,7 @@ enum AppHistoryNavigationType {
 };
 
 dictionary AppHistoryNavigationOptions {
-  any navigateInfo;
+  any info;
 };
 
 dictionary AppHistoryNavigateOptions : AppHistoryNavigationOptions {

--- a/app_history.d.ts
+++ b/app_history.d.ts
@@ -72,7 +72,7 @@ declare class AppHistoryEntry extends EventTarget {
 type AppHistoryNavigationType = 'reload'|'push'|'replace'|'traverse';
 
 interface AppHistoryNavigationOptions {
-  navigateInfo?: unknown;
+  info?: unknown;
 }
 
 interface AppHistoryNavigateOptions extends AppHistoryNavigationOptions {

--- a/spec.bs
+++ b/spec.bs
@@ -164,7 +164,7 @@ interface AppHistory : EventTarget {
 };
 
 dictionary AppHistoryNavigationOptions {
-  any navigateInfo;
+  any info;
 };
 
 dictionary AppHistoryNavigateOptions : AppHistoryNavigationOptions {
@@ -384,7 +384,7 @@ During any given navigation, the {{AppHistory}} object needs to keep track of th
       <td>For the duration of event firing
       <td>So that if the navigation is canceled while the event is firing, we can [=Event/canceled flag|cancel=] the event.
     <tr>
-      <td>Any {{AppHistoryNavigationOptions/navigateInfo}}
+      <td>Any {{AppHistoryNavigationOptions/info}}
       <td>Until the task is queued to fire the {{AppHistory/navigate}} event
       <td>So that we can use it to fire the {{AppHistory/navigate}} event after the the trip through the [=traversable navigable/session history traversal queue=]
     <tr>
@@ -490,7 +490,7 @@ An <dfn>app history API navigation</dfn> is a [=struct=] with the following [=st
     <p>Navigates the current page to the given <var ignore>url</var>. <var ignore>options</var> can contain the following values:
 
     * {{AppHistoryNavigateOptions/replace}} can be set to true to replace the current session history entry, instead of pushing a new one.
-    * {{AppHistoryNavigationOptions/navigateInfo}} can be set to any value; it will populate the {{AppHistoryNavigateEvent/info}} property of the corresponding {{AppHistory/navigate}} event.
+    * {{AppHistoryNavigationOptions/info}} can be set to any value; it will populate the {{AppHistoryNavigateEvent/info}} property of the corresponding {{AppHistory/navigate}} event.
     * {{AppHistoryNavigateOptions/state}} can be set to any [=serializable object|serializable=] value; it will populate the state retrieved by {{AppHistoryEntry/getState()|appHistory.current.getState()}} once the navigation completes, for same-document navigations. (It will be ignored for navigations that end up cross-document.)
 
     <p>By default this will perform a full navigation (i.e., a cross-document navigation, unless the given URL differs only in a fragment from the current one). The {{AppHistory/navigate}} event's {{AppHistoryNavigateEvent/respondWith()}} method can be used to convert it into a same-document navigation.
@@ -504,9 +504,9 @@ An <dfn>app history API navigation</dfn> is a [=struct=] with the following [=st
 
   <dt><code>await {{Window/appHistory}}.{{AppHistory/reload(options)|reload}}(<var ignore>options</var>)</code>
   <dd>
-    <p>Reloads the current page. <var ignore>options</var> needs to contain at least one of {{AppHistoryNavigationOptions/navigateInfo}} or {{AppHistoryReloadOptions/state}}, which behave as described above.
+    <p>Reloads the current page. The {{AppHistoryNavigationOptions/info}} and {{AppHistoryReloadOptions/state}} options behave as described above.
 
-    <p>The default behavior of performing a from-network-or-cache reload of the current page can be overriden by using the {{AppHistory/navigate}} event's {{AppHistoryNavigateEvent/respondWith()}} method. Doing so will mean this call only updates state or passes along the appropriate {{AppHistoryNavigationOptions/navigateInfo}}, plus performing whatever actions the {{AppHistory/navigate}} event handler sees fit to carry out.
+    <p>The default behavior of performing a from-network-or-cache reload of the current page can be overriden by using the {{AppHistory/navigate}} event's {{AppHistoryNavigateEvent/respondWith()}} method. Doing so will mean this call only updates state or passes along the appropriate {{AppHistoryNavigationOptions/info}}, plus performing whatever actions the {{AppHistory/navigate}} event handler sees fit to carry out.
 
     <p>The returned promise will behave as follows:
 
@@ -530,11 +530,11 @@ An <dfn>app history API navigation</dfn> is a [=struct=] with the following [=st
 
   1. If |options|["{{AppHistoryNavigateOptions/state}}"] [=map/exists=], then set |serializedState| to [$StructuredSerializeForStorage$](|options|["{{AppHistoryNavigateOptions/state}}"]). If this throws an exception, return [=a promise rejected with=] that exception.
 
-  1. Let |navigateInfo| be |options|["{{AppHistoryNavigationOptions/navigateInfo}}"] if it exists; otherwise, undefined.
+  1. Let |info| be |options|["{{AppHistoryNavigationOptions/info}}"] if it exists; otherwise, undefined.
 
   1. Let |historyHandling| be "<a for="history handling behavior">`replace`</a>" if |options|["{{AppHistoryNavigateOptions/replace}}"] is true; otherwise, "<a for="history handling behavior">`default`</a>".
 
-  1. Return the result of [=performing a non-traverse app history navigation=] given [=this=], |urlRecord|, |serializedState|, |navigateInfo|, and |historyHandling|.
+  1. Return the result of [=performing a non-traverse app history navigation=] given [=this=], |urlRecord|, |serializedState|, |info|, and |historyHandling|.
 </div>
 
 <div algorithm>
@@ -552,13 +552,13 @@ An <dfn>app history API navigation</dfn> is a [=struct=] with the following [=st
 
   1. Otherwise, if [=this=]'s [=AppHistory/current index=] is not &minus;1, then set |serializedState| to [=this=]'s [=AppHistory/entry list=][[=this=]'s [=AppHistory/current index=]]'s [=session history entry/app history state=].
 
-  1. Let |navigateInfo| be |options|["{{AppHistoryNavigationOptions/navigateInfo}}"] if it exists; otherwise, undefined.
+  1. Let |info| be |options|["{{AppHistoryNavigationOptions/info}}"] if it exists; otherwise, undefined.
 
-  1. Return the result of [=performing a non-traverse app history navigation=] given [=this=], |urlRecord|, |serializedState|, |navigateInfo|, and "<a for="history handling behavior">`reload`</a>".
+  1. Return the result of [=performing a non-traverse app history navigation=] given [=this=], |urlRecord|, |serializedState|, |info|, and "<a for="history handling behavior">`reload`</a>".
 </div>
 
 <div algorithm>
-  To <dfn>perform a non-traverse app history navigation</dfn> given an {{AppHistory}} object |appHistory|, a [=URL=] |url|, a [=serialized state=]-or-null |serializedState|, a JavaScript value |navigateInfo|, and a <a spec="HTML">history handling behavior</a> |historyHandling|:
+  To <dfn>perform a non-traverse app history navigation</dfn> given an {{AppHistory}} object |appHistory|, a [=URL=] |url|, a [=serialized state=]-or-null |serializedState|, a JavaScript value |info|, and a <a spec="HTML">history handling behavior</a> |historyHandling|:
 
   1. Let |browsingContext| be |appHistory|'s [=relevant global object=]'s [=Window/browsing context=].
 
@@ -566,7 +566,7 @@ An <dfn>app history API navigation</dfn> is a [=struct=] with the following [=st
 
   1. Assert: |historyHandling| is either "<a for="history handling behavior">`replace`</a>", "<a for="history handling behavior">`reload`</a>", or "<a for="history handling behavior">`default`</a>".
 
-  1. Let |ongoingNavigation| be the result of [=AppHistory/setting the upcoming non-traverse navigation=] for |appHistory| given |navigateInfo|.
+  1. Let |ongoingNavigation| be the result of [=AppHistory/setting the upcoming non-traverse navigation=] for |appHistory| given |info|.
 
   1. Set |appHistory|'s [=AppHistory/to-be-set serialized state=] to |serializedState|.
 
@@ -589,11 +589,11 @@ An <dfn>app history API navigation</dfn> is a [=struct=] with the following [=st
 
 <dl class="domintro non-normative">
   <dt><code>await {{Window/appHistory}}.{{AppHistory/goTo(key)|goTo}}(<var ignore>key</var>)</code>
-  <dt><code>await {{Window/appHistory}}.{{AppHistory/goTo(key, options)|goTo}}(<var ignore>key</var>, { {{AppHistoryNavigationOptions/navigateInfo}} })</code>
+  <dt><code>await {{Window/appHistory}}.{{AppHistory/goTo(key, options)|goTo}}(<var ignore>key</var>, { {{AppHistoryNavigationOptions/info}} })</code>
   <dd>
-    <p>Traverses the <a spec=HTML>joint session history</a> to the closest joint session history entry that matches the {{AppHistoryEntry}} with the given key. {{AppHistoryNavigationOptions/navigateInfo}} can be set to any value; it will populate the {{AppHistoryNavigateEvent/info}} property of the corresponding {{AppHistory/navigate}} event.
+    <p>Traverses the <a spec=HTML>joint session history</a> to the closest joint session history entry that matches the {{AppHistoryEntry}} with the given key. {{AppHistoryNavigationOptions/info}} can be set to any value; it will populate the {{AppHistoryNavigateEvent/info}} property of the corresponding {{AppHistory/navigate}} event.
 
-    <p>If a traversal to that <a spec=HTML>joint session history</a> is already in progress, then this will return a promise for that original traversal, and {{AppHistoryNavigationOptions/navigateInfo}} will be ignored.
+    <p>If a traversal to that <a spec=HTML>joint session history</a> is already in progress, then this will return a promise for that original traversal, and {{AppHistoryNavigationOptions/info}} will be ignored.
 
     <p>The returned promise will behave as follows:
 
@@ -604,11 +604,11 @@ An <dfn>app history API navigation</dfn> is a [=struct=] with the following [=st
   </dd>
 
   <dt><code>await {{Window/appHistory}}.{{AppHistory/back()|back}}()</code>
-  <dt><code>await {{Window/appHistory}}.{{AppHistory/back(options)|back}}({ {{AppHistoryNavigationOptions/navigateInfo}} })</code>
+  <dt><code>await {{Window/appHistory}}.{{AppHistory/back(options)|back}}({ {{AppHistoryNavigationOptions/info}} })</code>
   <dd>
-    <p>Traverse the <a spec=HTML>joint session history</a> to the closest previous joint session history entry which results in this frame navigating, i.e. results in {{AppHistory/current|appHistory.current}} updating. {{AppHistoryNavigationOptions/navigateInfo}} can be set to any value; it will populate the {{AppHistoryNavigateEvent/info}} property of the corresponding {{AppHistory/navigate}} event.
+    <p>Traverse the <a spec=HTML>joint session history</a> to the closest previous joint session history entry which results in this frame navigating, i.e. results in {{AppHistory/current|appHistory.current}} updating. {{AppHistoryNavigationOptions/info}} can be set to any value; it will populate the {{AppHistoryNavigateEvent/info}} property of the corresponding {{AppHistory/navigate}} event.
 
-    <p>If a traversal to that <a spec=HTML>joint session history</a> is already in progress, then this will return a promise for that original traversal, and {{AppHistoryNavigationOptions/navigateInfo}} will be ignored.
+    <p>If a traversal to that <a spec=HTML>joint session history</a> is already in progress, then this will return a promise for that original traversal, and {{AppHistoryNavigationOptions/info}} will be ignored.
 
     <p>The returned promise will behave as follows:
 
@@ -619,11 +619,11 @@ An <dfn>app history API navigation</dfn> is a [=struct=] with the following [=st
   </dd>
 
   <dt><code>await {{Window/appHistory}}.{{AppHistory/forward()|forward}}()</code>
-  <dt><code>await {{Window/appHistory}}.{{AppHistory/forward(options)|forward}}({ {{AppHistoryNavigationOptions/navigateInfo}} })</code>
+  <dt><code>await {{Window/appHistory}}.{{AppHistory/forward(options)|forward}}({ {{AppHistoryNavigationOptions/info}} })</code>
   <dd>
-    <p>Traverse the <a spec=HTML>joint session history</a> to the closest forward joint session history entry which results in this frame navigating, i.e. results in {{AppHistory/current|appHistory.current}} updating. {{AppHistoryNavigationOptions/navigateInfo}} can be set to any value; it will populate the {{AppHistoryNavigateEvent/info}} property of the corresponding {{AppHistory/navigate}} event.
+    <p>Traverse the <a spec=HTML>joint session history</a> to the closest forward joint session history entry which results in this frame navigating, i.e. results in {{AppHistory/current|appHistory.current}} updating. {{AppHistoryNavigationOptions/info}} can be set to any value; it will populate the {{AppHistoryNavigateEvent/info}} property of the corresponding {{AppHistory/navigate}} event.
 
-    <p>If a traversal to that <a spec=HTML>joint session history</a> is already in progress, then this will return a promise for that original traversal, and {{AppHistoryNavigationOptions/navigateInfo}} will be ignored.
+    <p>If a traversal to that <a spec=HTML>joint session history</a> is already in progress, then this will return a promise for that original traversal, and {{AppHistoryNavigationOptions/info}} will be ignored.
 
     <p>The returned promise will behave as follows:
 
@@ -681,7 +681,7 @@ An <dfn>app history API navigation</dfn> is a [=struct=] with the following [=st
 
   1. Let |initiatorBC| be |appHistory|'s [=relevant global object=]'s [=Window/browsing context=].
 
-  1. Let |info| be |options|["{{AppHistoryNavigationOptions/navigateInfo}}"] if it [=map/exists=], or undefined otherwise.
+  1. Let |info| be |options|["{{AppHistoryNavigationOptions/info}}"] if it [=map/exists=], or undefined otherwise.
 
   1. If |appHistory|'s [=AppHistory/ongoing traverse navigations=][|key|] [=map/exists=], then return |appHistory|'s [=AppHistory/ongoing traverse navigations=][|key|]'s [=app history API navigation/returned promise=].
 


### PR DESCRIPTION
Also fix an incorrect sentence in the for-web-developers description of reload().

Closes #134.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/app-history/pull/145.html" title="Last updated on Aug 6, 2021, 7:15 PM UTC (93e52bb)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/app-history/145/0e75539...93e52bb.html" title="Last updated on Aug 6, 2021, 7:15 PM UTC (93e52bb)">Diff</a>