### PR TITLE
Add appHistory.updateCurrent() to close #115

### DIFF
--- a/app_history.d.ts
+++ b/app_history.d.ts
@@ -9,10 +9,10 @@ interface AppHistoryEventMap {
 }
 
 declare class AppHistory extends EventTarget {
-  readonly current: AppHistoryEntry|null;
-  readonly transition: AppHistoryTransition|null;
-
   entries(): AppHistoryEntry[];
+  readonly current: AppHistoryEntry|null;
+  updateCurrent(options: AppHistoryUpdateCurrentOptions): void;
+  readonly transition: AppHistoryTransition|null;
 
   readonly canGoBack: boolean;
   readonly canGoForward: boolean;
@@ -70,6 +70,10 @@ declare class AppHistoryEntry extends EventTarget {
 }
 
 type AppHistoryNavigationType = 'reload'|'push'|'replace'|'traverse';
+
+interface AppHistoryUpdateCurrentOptions {
+  state: unknown;
+}
 
 interface AppHistoryNavigationOptions {
   info?: unknown;

--- a/spec.bs
+++ b/spec.bs
@@ -147,6 +147,7 @@ The <dfn attribute for="Window">appHistory</dfn> getter steps are to return [=th
 interface AppHistory : EventTarget {
   sequence<AppHistoryEntry> entries();
   readonly attribute AppHistoryEntry? current;
+  undefined updateCurrent(AppHistoryUpdateCurrentOptions options);
 
   readonly attribute boolean canGoBack;
   readonly attribute boolean canGoForward;
@@ -161,6 +162,10 @@ interface AppHistory : EventTarget {
   attribute EventHandler onnavigate;
   attribute EventHandler onnavigatesuccess;
   attribute EventHandler onnavigateerror;
+};
+
+dictionary AppHistoryUpdateCurrentOptions {
+  required any state;
 };
 
 dictionary AppHistoryNavigationOptions {
@@ -185,11 +190,6 @@ dictionary AppHistoryReloadOptions : AppHistoryNavigationOptions {
     <p>Returns an array of {{AppHistoryEntry}} instances representing the current app history list, i.e. all session history entries for this {{Window}} that are [=same origin=] and contiguous to the current session history entry.
   </dd>
 
-  <dt><code>{{Window/appHistory}}.{{AppHistory/current}}</code>
-  <dd>
-    <p>The current {{AppHistoryEntry}}.
-  </dd>
-
   <dt><code>{{Window/appHistory}}.{{AppHistory/canGoBack}}</code>
   <dd>
     <p>Returns true if the current {{AppHistoryEntry}} is not the first one in the app history entries list.
@@ -211,18 +211,6 @@ Each {{AppHistory}} object has an associated <dfn for="AppHistory">current index
   1. If [=this=]'s [=relevant global object=]'s [=associated Document=] is not [=Document/fully active=], then return the empty list.
 
   1. Return [=this=]'s [=AppHistory/entries list=].
-</div>
-
-<div algorithm>
-  The <dfn attribute for="AppHistory">current</dfn> getter steps are:
-
-  1. If [=this=]'s [=relevant global object=]'s [=associated Document=] is not [=Document/fully active=], then return null.
-
-  1. If [=this=]'s [=AppHistory/current index=] is &minus;1, then return null.
-
-     <p class="note">This occurs if accessing the API while on the initial `about:blank` {{Document}}, where the [=AppHistory/update the entries=] algorithm will not yet have been run to completion.
-
-  1. Return [=this=]'s [=AppHistory/entry list=][[=this=]'s [=AppHistory/current index=]].
 </div>
 
 <div algorithm>
@@ -339,6 +327,46 @@ Each {{AppHistory}} object has an associated <dfn for="AppHistory">current index
     1. Increment |index| by 1.
 
   1. Assert: this step is never reached.
+</div>
+
+<h3 id="current-entry">The current entry</h3>
+
+<dl class="domintro non-normative">
+  <dt><code>{{Window/appHistory}}.{{AppHistory/current}}</code>
+  <dd>
+    <p>The current {{AppHistoryEntry}}.
+  </dd>
+
+  <dt><code>{{Window/appHistory}}.{{AppHistory/updateCurrent()|updateCurrent}}({ {{AppHistoryUpdateCurrentOptions/state}} })</code>
+  <dd>
+    <p>Update the [=session history entry/app history state=] of the current {{AppHistoryEntry}}, without performing a navigation like {{AppHistory/reload()|appHistory.reload()}} would do.
+
+    <p>This method is best used to capture updates to the page that have already happened, and need to be reflected into the app history state. For cases where the state update is meant to drive a page update, instead use {{AppHistory/navigate()|appHistory.navigate()}} or {{AppHistory/reload()|appHistory.reload()}}.
+  </dd>
+</dl>
+
+<div algorithm>
+  The <dfn attribute for="AppHistory">current</dfn> getter steps are:
+
+  1. If [=this=]'s [=relevant global object=]'s [=associated Document=] is not [=Document/fully active=], then return null.
+
+  1. If [=this=]'s [=AppHistory/current index=] is &minus;1, then return null.
+
+     <p class="note">This occurs if accessing the API while on the initial `about:blank` {{Document}}, where the [=AppHistory/update the entries=] algorithm will not yet have been run to completion.
+
+  1. Return [=this=]'s [=AppHistory/entry list=][[=this=]'s [=AppHistory/current index=]].
+</div>
+
+<div algorithm>
+  The <dfn method for="AppHistory">updateCurrent(|options|)</dfn> method steps are:
+
+  1. If [=this=]'s [=relevant global object=]'s [=associated Document=] is not [=Document/fully active=], then throw an "{{InvalidStateError}}" {{DOMException}}.
+
+  1. If [=this=]'s [=AppHistory/current index=] is &minus;1, then throw an "{{InvalidStateError}}" {{DOMException}}.
+
+  1. Let |serializedState| be [$StructuredSerializeForStorage$](|options|["{{AppHistoryUpdateCurrentOptions/state}}"]), rethrowing any exceptions.
+
+  1. Set [=this=]'s [=AppHistory/entry list=][[=this=]'s [=AppHistory/current index=]]'s [=AppHistoryEntry/session history entry=]'s [=session history entry/app history state=] to |serializedState|.
 </div>
 
 <h3 id="ongoing-state">Ongoing navigation tracking</h3>


### PR DESCRIPTION
Review appreciated from any watchers on the explainer updates and d.ts updates.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 500 Internal Server Error :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Aug 10, 2021, 5:32 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [CSS Spec Preprocessor](https://api.csswg.org/bikeshed/) - CSS Spec Preprocessor is the web service used to build Bikeshed specs.

:link: [Related URL](https://api.csswg.org/bikeshed/?url=https%3A%2F%2Fraw.githubusercontent.com%2FWICG%2Fapp-history%2Fa57b672385a810b19d2b22d5c3f4307491e8bf20%2Fspec.bs&md-warning=not%20ready)

```
Error running preprocessor, returned code: 1.
Traceback (most recent call last):
  File "/sites/api.csswg.org/bikeshed/bikeshed.py", line 6, in 
    cli.main()
  File "/sites/api.csswg.org/bikeshed/bikeshed/cli.py", line 466, in main
    handleSpec(options, extras)
  File "/sites/api.csswg.org/bikeshed/bikeshed/cli.py", line 515, in handleSpec
    lineNumbers=options.lineNumbers,
  File "/sites/api.csswg.org/bikeshed/bikeshed/Spec.py", line 61, in __init__
    self.inputSource = InputSource(inputFilename, chroot=constants.chroot)
  File "/sites/api.csswg.org/bikeshed/bikeshed/InputSource.py", line 51, in __new__
    return UrlInputSource(sourceName, **kwargs)
TypeError: __init__() got an unexpected keyword argument 'chroot'
```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20WICG/app-history%23146.)._
</details>
