### PR TITLE
Give non-default values for aborted navigation ErrorEvent properties

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -1196,7 +1196,8 @@ The <dfn attribute for="AppHistoryDestination">sameDocument</dfn> getter steps a
     1. [=Reject=] |appHistory|'s [=AppHistory/transition=]'s [=AppHistoryTransition/finished promise=] with |error|.
     1. Set |appHistory|'s [=AppHistory/transition=] to null.
   1. If |ongoingNavigation| is non-null, then:
-    1. If |ongoingNavigation|'s [=app history API navigation/fired navigate event=] is true, then [=fire an event=] named {{AppHistory/navigateerror}} at |appHistory| using {{ErrorEvent}}, with {{ErrorEvent/error}} initialized to |error|, {{ErrorEvent/message}} initialized to the value of |error|'s {{DOMException/message}} property, {{ErrorEvent/filename}} initialized to the empty string, and {{ErrorEvent/lineno}} and {{ErrorEvent/colno}} initialized to 0.
+    1. If |ongoingNavigation|'s [=app history API navigation/fired navigate event=] is true, then [=fire an event=] named {{AppHistory/navigateerror}} at |appHistory| using {{ErrorEvent}}, with {{ErrorEvent/error}} initialized to |error|, and {{ErrorEvent/message}}, {{ErrorEvent/filename}}, {{ErrorEvent/lineno}}, and {{ErrorEvent/colno}} initialized to appropriate values that can be extracted from |error| and the current JavaScript stack in the same underspecified way the user agent typically does for the <a spec="HTML">report an exception</a> algorithm.
+       <p class="note">Thus, for example, if this algorithm is reached because of a call to {{Window/stop()|window.stop()}}, these properties would probably end up initialized based on the line of script that called {{Window/stop()|window.stop()}}. But if it's because the user clicked the stop button, these properties would probably end up with default values like the empty string or 0.
     1. [=Reject=] |ongoingNavigation|'s [=app history API navigation/returned promise=] with |error|.
     1. Perform |ongoingNavigation|'s [=app history API navigation/cleanup step=].
 </div>


### PR DESCRIPTION
Apparently this is more aligned with at least the Chromium implementation. We can revisit if this is hard to get interop on.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/app-history/pull/149.html" title="Last updated on Aug 13, 2021, 9:40 PM UTC (844de32)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/app-history/149/7485009...844de32.html" title="Last updated on Aug 13, 2021, 9:40 PM UTC (844de32)">Diff</a>