### PR TITLE
Fix state tracking for multiple navigations

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -532,7 +532,7 @@ We end up accomplishing all this using the following setup:
 
 Each {{AppHistory}} object has an associated <dfn for="AppHistory">ongoing navigate event</dfn>, an {{AppHistoryNavigateEvent}} or null, initially null.
 
-Each {{AppHistory}} object has an associated <dfn for="AppHistory">to-be-set serialized state</dfn>, a [=serialized state=] or null, initially null.
+Each {{AppHistory}} object has an associated <dfn for="AppHistory">post-navigate event ongoing navigation signal</dfn>, which is an {{AbortSignal}} or null, initially null.
 
 Each {{AppHistory}} object has an associated <dfn for="AppHistory">upcoming non-traverse navigation</dfn>, which is an [=app history API navigation=] or null, initially null.
 
@@ -540,24 +540,23 @@ Each {{AppHistory}} object has an associated <dfn for="AppHistory">ongoing non-t
 
 Each {{AppHistory}} object has an associated <dfn for="AppHistory">ongoing traverse navigations</dfn>, which is a [=map=] from strings to [=app history API navigations=], initially empty.
 
-Each {{AppHistory}} object has an associated <dfn for="AppHistory">post-navigate event ongoing navigation signal</dfn>, which is an {{AbortSignal}} or null, initially null.
-
 An <dfn>app history API navigation</dfn> is a [=struct=] with the following [=struct/items=]:
 
 * An <dfn for="app history API navigation">info</dfn>, a JavaScript value
+* An <dfn for="app history API navigation">serialized state</dfn>, a [=serialized state=] or null
 * A <dfn for="app history API navigation">returned promise</dfn>, a {{Promise}}
 * A <dfn for="app history API navigation">cleanup step</dfn>, an algorithm step
 
 <p class="note">We need to store the {{AbortSignal}} separately from the [=app history API navigation=] struct, since it needs to be tracked even for navigations that are not via the app history APIs. So, we store it some of the time in the [=AppHistory/ongoing navigate event=]'s {{AppHistoryNavigateEvent/signal}} property, and the rest of the time in the [=AppHistory/post-navigate event ongoing navigation signal=].
 
 <div algorithm>
-  To <dfn for="AppHistory">set the upcoming non-traverse navigation</dfn> given an {{AppHistory}} |appHistory| and a JavaScript value |info|:
+  To <dfn for="AppHistory">set the upcoming non-traverse navigation</dfn> given an {{AppHistory}} |appHistory|, a JavaScript value |info|, and a [=serialized state=]-or-null |serializedState|:
 
   1. Let |promise| be [=a new promise=] created in |appHistory|'s [=relevant Realm=].
 
   1. Let |cleanupStep| be an algorithm step which sets |appHistory|'s [=AppHistory/ongoing non-traverse navigation=] to null.
 
-  1. Let |ongoingNavigation| be an [=app history API navigation=] whose [=app history API navigation/info=] is |info|, [=app history API navigation/returned promise=] is |promise|, and [=app history API navigation/cleanup step=] is |cleanupStep|.
+  1. Let |ongoingNavigation| be an [=app history API navigation=] whose [=app history API navigation/info=] is |info|, [=app history API navigation/serialized state=] is |serializedState|, [=app history API navigation/returned promise=] is |promise|, and [=app history API navigation/cleanup step=] is |cleanupStep|.
 
   1. Assert: |appHistory|'s [=AppHistory/upcoming non-traverse navigation=] is null.
 
@@ -583,7 +582,7 @@ An <dfn>app history API navigation</dfn> is a [=struct=] with the following [=st
 
   1. Let |cleanupStep| be an algorithm step which [=map/removes=] |appHistory|'s [=AppHistory/ongoing traverse navigations=][|key|].
 
-  1. Let |ongoingNavigation| be an [=app history API navigation=] whose [=app history API navigation/info=] is |info|, [=app history API navigation/returned promise=] is |promise|, and [=app history API navigation/cleanup step=] is |cleanupStep|.
+  1. Let |ongoingNavigation| be an [=app history API navigation=] whose [=app history API navigation/info=] is |info|, [=app history API navigation/serialized state=] is null, [=app history API navigation/returned promise=] is |promise|, and [=app history API navigation/cleanup step=] is |cleanupStep|.
 
   1. Set |appHistory|'s [=AppHistory/ongoing traverse navigations=][|key|]  to |ongoingNavigation|.
 
@@ -675,9 +674,7 @@ An <dfn>app history API navigation</dfn> is a [=struct=] with the following [=st
 
   1. Assert: |historyHandling| is either "<a for="history handling behavior">`replace`</a>", "<a for="history handling behavior">`reload`</a>", or "<a for="history handling behavior">`default`</a>".
 
-  1. Let |ongoingNavigation| be the result of [=AppHistory/setting the upcoming non-traverse navigation=] for |appHistory| given |info|.
-
-  1. Set |appHistory|'s [=AppHistory/to-be-set serialized state=] to |serializedState|.
+  1. Let |ongoingNavigation| be the result of [=AppHistory/setting the upcoming non-traverse navigation=] for |appHistory| given |info| and |serializedState|.
 
   1. <a spec="HTML">Navigate</a> |browsingContext| to |url| with <i>[=navigate/historyHandling=]</i> set to |historyHandling|, <i>[=navigate/appHistoryState=]</i> set to |serializedState|, and the <a spec="HTML">source browsing context</a> set to |browsingContext|.
 
@@ -689,9 +686,9 @@ An <dfn>app history API navigation</dfn> is a [=struct=] with the following [=st
 
     1. Return [=a promise rejected with=] an "{{AbortError}}" {{DOMException}}.
 
-  1. If |appHistory|'s [=AppHistory/to-be-set serialized state=] is non-null, then set |browsingContext|'s [=session history=]'s [=session history/current entry=]'s [=session history entry/app history state=] to |appHistory|'s [=AppHistory/to-be-set serialized state=].
+  1. If |ongoingNavigation|'s [=app history API navigation/serialized state=] is non-null, then set |browsingContext|'s [=session history=]'s [=session history/current entry=]'s [=session history entry/app history state=] to |ongoingNavigation|'s [=app history API navigation/serialized state=].
 
-  1. Set |appHistory|'s [=AppHistory/to-be-set serialized state=] to null.
+     <p class="note">At this point |ongoingNavigation|'s [=app history API navigation/serialized state=] is no longer needed and can be nulled out instead of keeping it alive for the lifetime of the [=app history API navigation=].
 
   1. Return |ongoingNavigation|'s [=app history API navigation/returned promise=].
 </div>
@@ -1137,12 +1134,9 @@ The <dfn attribute for="AppHistoryDestination">sameDocument</dfn> getter steps a
   1. Let |dispatchResult| be the result of [=dispatching=] |event| at |appHistory|.
   1. Let |shouldContinue| be |dispatchResult|.
   1. Set |appHistory|'s [=AppHistory/ongoing navigate event=] to null.
+  1. If |event|'s {{AppHistoryNavigateEvent/signal}}'s [=AbortSignal/aborted flag=] is set, then return false.
+     <p class="note">This can occur if an event listener performed an action that triggers [=inform app history about canceling navigation=], such as disconnecting a containing <{iframe}> or starting another navigation.
   1. Set |appHistory|'s [=AppHistory/post-navigate event ongoing navigation signal=] to |event|'s {{AppHistoryNavigateEvent/signal}}.
-  1. If |appHistory|'s [=relevant global object=]'s [=active Document=] is not [=Document/fully active=], then:
-    1. [=Finalize with an aborted navigation error=] given |appHistory| and |ongoingNavigation|.
-    1. Return false.
-
-    <p class="note">This can occur if an event listener disconnected the <{iframe}> corresponding to [=this=]'s [=relevant global object=].
   1. If |dispatchResult| is true:
     1. Assert: |appHistory|'s [=AppHistory/current index=] is not &minus;1.
     1. Let |fromEntry| be |appHistory|'s [=AppHistory/entry list=][|appHistory|'s [=AppHistory/current index=]].
@@ -1170,11 +1164,9 @@ The <dfn attribute for="AppHistoryDestination">sameDocument</dfn> getter steps a
           1. Perform |ongoingNavigation|'s [=app history API navigation/cleanup step=].
 
       <p class="note">If |event|'s [=AppHistoryNavigateEvent/navigation action promises list=] is non-empty, then {{AppHistoryNavigateEvent/transitionWhile()}} was called and so we're performing a same-document navigation, for which we want to fire {{AppHistory/navigatesuccess}} or {{AppHistory/navigateerror}} events, and resolve or reject the promise returned by the corresponding {{AppHistory/navigate()|appHistory.navigate()}} call if one exists. Otherwise, if the navigation is same-document and was not canceled, we still perform these actions after a microtask (by waiting for zero promises), or after the appropriate task in the traversal case.
-    1. Otherwise:
-      1. Set |appHistory|'s [=AppHistory/to-be-set serialized state=] to null.
-
-      <p class="note">This ensures that any call to {{AppHistory/navigate()|appHistory.navigate()}} which triggered this algorithm does not overwrite the [=session history entry/app history state=] of the [=session history/current entry=] for cross-document navigations.
-  1. Otherwise, if |navigationType| is not "{{AppHistoryNavigationType/traverse}}" and |event|'s {{AppHistoryNavigateEvent/signal}}'s [=AbortSignal/aborted flag=] is not set, then [=finalize with an aborted navigation error=] given |appHistory| and |ongoingNavigation|.
+    1. Otherwise, if |ongoingNavigation| is non-null, then set |ongoingNavigation|'s [=app history API navigation/serialized state=] to null.
+       <p class="note">This ensures that any call to {{AppHistory/navigate()|appHistory.navigate()}} which triggered this algorithm does not overwrite the [=session history entry/app history state=] of the [=session history/current entry=] for cross-document navigations.
+  1. Otherwise, if |navigationType| is not "{{AppHistoryNavigationType/traverse}}", then [=finalize with an aborted navigation error=] given |appHistory| and |ongoingNavigation|.
      <p class="note">If |navigationType| is "{{AppHistoryNavigationType/traverse}}", then we will [=finalize with an aborted navigation error=] in [=perform an app history traversal=].
   1. Return |shouldContinue|.
 </div>
@@ -1189,19 +1181,18 @@ The <dfn attribute for="AppHistoryDestination">sameDocument</dfn> getter steps a
     1. Set |appHistory|'s [=AppHistory/ongoing navigate event=] to null.
   1. Otherwise, set |signal| to |appHistory|'s [=AppHistory/post-navigate event ongoing navigation signal=].
   1. Set |appHistory|'s [=AppHistory/post-navigate event ongoing navigation signal=] to null.
-  1. Set |appHistory|'s [=AppHistory/to-be-set serialized state=] to null.
-
-     <p class="note">This ensures that any call to {{AppHistory/navigate()|appHistory.navigate()}} which triggered this algorithm does not overwrite the [=session history entry/app history state=] of the [=session history/current entry=] for aborted navigations.
   1. If |signal| is not null, then [=AbortSignal/signal abort=] on |signal|.
   1. If |error| was not given, then set |error| to a [=new=] "{{AbortError}}" {{DOMException}}, created in |appHistory|'s [=relevant Realm=].
   1. If |appHistory|'s [=AppHistory/transition=] is not null, then:
     1. [=Reject=] |appHistory|'s [=AppHistory/transition=]'s [=AppHistoryTransition/finished promise=] with |error|.
     1. Set |appHistory|'s [=AppHistory/transition=] to null.
-  1. [=Fire an event=] named {{AppHistory/navigateerror}} at |appHistory| using {{ErrorEvent}}, with {{ErrorEvent/error}} initialized to |error|, and {{ErrorEvent/message}}, {{ErrorEvent/filename}}, {{ErrorEvent/lineno}}, and {{ErrorEvent/colno}} initialized to appropriate values that can be extracted from |error| and the current JavaScript stack in the same underspecified way the user agent typically does for the <a spec="HTML">report an exception</a> algorithm.
-    <p class="note">Thus, for example, if this algorithm is reached because of a call to {{Window/stop()|window.stop()}}, these properties would probably end up initialized based on the line of script that called {{Window/stop()|window.stop()}}. But if it's because the user clicked the stop button, these properties would probably end up with default values like the empty string or 0.
   1. If |ongoingNavigation| is non-null, then:
+    1. Set |ongoingNavigation|'s [=app history API navigation/serialized state=] to null.
+       <p class="note">This ensures that any call to {{AppHistory/navigate()|appHistory.navigate()}} which triggered this algorithm does not overwrite the [=session history entry/app history state=] of the [=session history/current entry=] for aborted navigations.
     1. [=Reject=] |ongoingNavigation|'s [=app history API navigation/returned promise=] with |error|.
     1. Perform |ongoingNavigation|'s [=app history API navigation/cleanup step=].
+  1. [=Fire an event=] named {{AppHistory/navigateerror}} at |appHistory| using {{ErrorEvent}}, with {{ErrorEvent/error}} initialized to |error|, and {{ErrorEvent/message}}, {{ErrorEvent/filename}}, {{ErrorEvent/lineno}}, and {{ErrorEvent/colno}} initialized to appropriate values that can be extracted from |error| and the current JavaScript stack in the same underspecified way the user agent typically does for the <a spec="HTML">report an exception</a> algorithm.
+    <p class="note">Thus, for example, if this algorithm is reached because of a call to {{Window/stop()|window.stop()}}, these properties would probably end up initialized based on the line of script that called {{Window/stop()|window.stop()}}. But if it's because the user clicked the stop button, these properties would probably end up with default values like the empty string or 0.
 </div>
 
 <div algorithm>


### PR DESCRIPTION
Previously starting a new navigation would reset the to-be-set serialized state, which broke our attempt to afterward set the current session history entry's app history state. Instead we now track the state in the ongoing navigation struct.

Follows https://chromium-review.googlesource.com/c/chromium/src/+/3101394.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/app-history/pull/155.html" title="Last updated on Aug 18, 2021, 6:08 PM UTC (0cb673e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/app-history/155/33a3904...0cb673e.html" title="Last updated on Aug 18, 2021, 6:08 PM UTC (0cb673e)">Diff</a>