### PR TITLE
Consolidate ongoing navigation signal tracking

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -45,6 +45,8 @@ spec: html; urlPrefix: https://html.spec.whatwg.org/multipage/
       text: historyHandling; url: browsing-the-web.html#navigation-hh
       text: navigationType; url: browsing-the-web.html#navigation-navigationtype
       text: exceptionsEnabled; url: browsing-the-web.html#exceptions-enabled
+    for: browsing context
+      text: discard; url: window-object.html#a-browsing-context-is-discarded
   type: method
     for: Document; text: open(unused1, unused2); url: multipage/dynamic-markup-insertion.html#dom-document-open
 spec: html; urlPrefix: https://whatpr.org/html/6315/
@@ -1198,18 +1200,19 @@ The <dfn attribute for="AppHistoryDestination">sameDocument</dfn> getter steps a
   1. Let |appHistory| be |bc|'s [=browsing context/active window=]'s [=Window/app history=].
   1. If |appHistory|'s [=AppHistory/ongoing navigation signal=] is null, then return.
   1. Let |ongoingNavigation| be |appHistory|'s [=AppHistory/ongoing non-traverse navigation=].
-  1. If |ongoingNavigation| is null, and the navigation being canceled is an "<a for="history handling behavior">`entry update`</a>" navigation that originally came from traversal to a [=session history entry=] |she|, then:
-    <p class="advisement">This predicate should be made more precise when we define navigation cancelation in detail.</p>
-    1. Let |key| be |she|'s [=session history entry/app history key=].
-    1. If |appHistory|'s [=AppHistory/ongoing traverse navigations=][|key|] exists, then set |ongoingNavigation| to [=AppHistory/ongoing traverse navigations=][|key|].
+  1. If |ongoingNavigation| is null, and |appHistory|'s [=AppHistory/ongoing navigate event=] is non-null, then:
+    1. Let |key| be |appHistory|'s [=AppHistory/ongoing navigate event=]'s {{AppHistoryNavigateEvent/destination}}'s [=AppHistoryDestination/key=].
+    1. If |appHistory|'s [=AppHistory/ongoing traverse navigations=][|key|] exists, then set |ongoingNavigation| to |appHistory|'s [=AppHistory/ongoing traverse navigations=][|key|].
+
+    <p class="note">This case will only be triggered if this algorithm is called by [=inform app history about browsing context discarding=]. In particular, it can happen if the browsing context is [=browsing context/discarded=] during the firing of the {{AppHistory/navigate}} event.
   1. [=Finalize with an aborted navigation error=] given |appHistory| and |ongoingNavigation|.
 </div>
 
 <div algorithm>
-  To <dfn>inform app history about canceling traversals</dfn> in a [=browsing context=] |bc|:
+  To <dfn>inform app history about browsing context discarding</dfn> given a [=browsing context=] |bc|:
 
+  1. [=Inform app history about canceling navigation=] in |bc|.
   1. Let |appHistory| be |bc|'s [=browsing context/active window=]'s [=Window/app history=].
-  1. If |appHistory|'s [=AppHistory/ongoing navigation signal=] is null, then return.
   1. Let |traversals| be a [=list/clone=] of |appHistory|'s [=AppHistory/ongoing traverse navigations=].
   1. For each |ongoingTraversal| of |traversals|: [=finalize with an aborted navigation error=] given |appHistory| and |ongoingTraversal|.
 </div>
@@ -1592,7 +1595,9 @@ Specifically, the spec uses a few phrases:
 
 * "Remove any tasks queued by the history traversal task source that are associated with any Document objects in the top-level browsing context's document family." This cancels queued-up traversals that have not yet made their way back to the main event loop. This is currently called from any same-document navigations, i.e. the <a spec="HTML">URL and history update steps</a> and <a spec="HTML">navigating to a fragment</a>, as well as as part of <a spec="HTML">traverse the history</a> for cross-document traversals.
 
-We assume that the eventual model will retain essentially these two primitives: canceling not-yet-mature navigations, and canceling queued-up traversals. When exactly these two operations will be invoked is dependent on how the discussion goes in <a href="https://github.com/whatwg/html/issues/6927">whatwg/html#6927</a>.
+<a href="https://github.com/whatwg/html/issues/6927">whatwg/html#6927</a> reveals that implementations don't really follow this breakdown. In particular, modulo one case in Firefox, traversals are only canceled as part of [=browsing context/discarding=] a browsing context.
+
+That leaves us with two main operations: canceling not-yet-mature navigations, and dealing with browsing context discarding.
 
 <hr>
 
@@ -1615,6 +1620,6 @@ Without the {{AppHistory/navigate}} event handler, this kind of synchronous frag
 
 The integration is then as follows:
 
-* Wherever the spec ends up canceling not-yet-mature navigations for a browsing context |bc|, we also [=inform app history about canceling navigation=] in |bc|. (Regardless of whether or not there are any not-yet-mature navigations still in flight.)
+* Wherever the spec ends up canceling not-yet-mature navigations for a [=browsing context=] |bc|, we also [=inform app history about canceling navigation=] in |bc|. (Regardless of whether or not there are any not-yet-mature navigations still in flight.)
 
-* Wherever the spec ends up canceling queued-up traversals for a browsing context |bc|, we also [=inform app history about canceling traversals=] in |bc|. (Regardless of whether or not there are any traversals queued up.)
+* When the spec [=browsing context/discards=] a [=browsing context=] |bc|, we also [=inform app history about browsing context discarding=] given |bc|. (Regardless of whether or not there are any not-yet-mature navigations still in fligh, or any traversals queued up.)

--- a/spec.bs
+++ b/spec.bs
@@ -532,7 +532,7 @@ We end up accomplishing all this using the following setup:
 
 Each {{AppHistory}} object has an associated <dfn for="AppHistory">ongoing navigate event</dfn>, an {{AppHistoryNavigateEvent}} or null, initially null.
 
-Each {{AppHistory}} object has an associated <dfn for="AppHistory">post-navigate event ongoing navigation signal</dfn>, which is an {{AbortSignal}} or null, initially null.
+Each {{AppHistory}} object has an associated <dfn for="AppHistory">ongoing navigation signal</dfn>, which is an {{AbortSignal}} or null, initially null.
 
 Each {{AppHistory}} object has an associated <dfn for="AppHistory">upcoming non-traverse navigation</dfn>, which is an [=app history API navigation=] or null, initially null.
 
@@ -547,7 +547,7 @@ An <dfn>app history API navigation</dfn> is a [=struct=] with the following [=st
 * A <dfn for="app history API navigation">returned promise</dfn>, a {{Promise}}
 * A <dfn for="app history API navigation">cleanup step</dfn>, an algorithm step
 
-<p class="note">We need to store the {{AbortSignal}} separately from the [=app history API navigation=] struct, since it needs to be tracked even for navigations that are not via the app history APIs. So, we store it some of the time in the [=AppHistory/ongoing navigate event=]'s {{AppHistoryNavigateEvent/signal}} property, and the rest of the time in the [=AppHistory/post-navigate event ongoing navigation signal=].
+<p class="note">We need to store the [=AppHistory/ongoing navigation signal=] separately from the [=app history API navigation=] struct, since it needs to be tracked even for navigations that are not via the app history APIs.
 
 <div algorithm>
   To <dfn for="AppHistory">set the upcoming non-traverse navigation</dfn> given an {{AppHistory}} |appHistory|, a JavaScript value |info|, and a [=serialized state=]-or-null |serializedState|:
@@ -1131,12 +1131,11 @@ The <dfn attribute for="AppHistoryDestination">sameDocument</dfn> getter steps a
   1. If |formDataEntryList| is not null, then initialize |event|'s {{AppHistoryNavigateEvent/formData}} to a [=new=] {{FormData}} created in |appHistory|'s [=relevant Realm=], associated to |formDataEntryList|. Otherwise, initialize it to null.
   1. [=Assert=]: |appHistory|'s [=AppHistory/ongoing navigate event=] is null.
   1. Set |appHistory|'s [=AppHistory/ongoing navigate event=] to |event|.
+  1. [=Assert=]: |appHistory|'s [=AppHistory/ongoing navigation signal=] is null.
+  1. Set |appHistory|'s [=AppHistory/ongoing navigation signal=] to |event|'s {{AppHistoryNavigateEvent/signal}}.
   1. Let |dispatchResult| be the result of [=dispatching=] |event| at |appHistory|.
   1. Let |shouldContinue| be |dispatchResult|.
   1. Set |appHistory|'s [=AppHistory/ongoing navigate event=] to null.
-  1. If |event|'s {{AppHistoryNavigateEvent/signal}}'s [=AbortSignal/aborted flag=] is set, then return false.
-     <p class="note">This can occur if an event listener performed an action that triggers [=inform app history about canceling navigation=], such as disconnecting a containing <{iframe}> or starting another navigation.
-  1. Set |appHistory|'s [=AppHistory/post-navigate event ongoing navigation signal=] to |event|'s {{AppHistoryNavigateEvent/signal}}.
   1. If |dispatchResult| is true:
     1. Assert: |appHistory|'s [=AppHistory/current index=] is not &minus;1.
     1. Let |fromEntry| be |appHistory|'s [=AppHistory/entry list=][|appHistory|'s [=AppHistory/current index=]].
@@ -1166,7 +1165,7 @@ The <dfn attribute for="AppHistoryDestination">sameDocument</dfn> getter steps a
       <p class="note">If |event|'s [=AppHistoryNavigateEvent/navigation action promises list=] is non-empty, then {{AppHistoryNavigateEvent/transitionWhile()}} was called and so we're performing a same-document navigation, for which we want to fire {{AppHistory/navigatesuccess}} or {{AppHistory/navigateerror}} events, and resolve or reject the promise returned by the corresponding {{AppHistory/navigate()|appHistory.navigate()}} call if one exists. Otherwise, if the navigation is same-document and was not canceled, we still perform these actions after a microtask (by waiting for zero promises), or after the appropriate task in the traversal case.
     1. Otherwise, if |ongoingNavigation| is non-null, then set |ongoingNavigation|'s [=app history API navigation/serialized state=] to null.
        <p class="note">This ensures that any call to {{AppHistory/navigate()|appHistory.navigate()}} which triggered this algorithm does not overwrite the [=session history entry/app history state=] of the [=session history/current entry=] for cross-document navigations.
-  1. Otherwise, if |navigationType| is not "{{AppHistoryNavigationType/traverse}}", then [=finalize with an aborted navigation error=] given |appHistory| and |ongoingNavigation|.
+  1. Otherwise, if |navigationType| is not "{{AppHistoryNavigationType/traverse}}" and |event|'s {{AppHistoryNavigateEvent/signal}}'s [=AbortSignal/aborted flag=] is unset, then [=finalize with an aborted navigation error=] given |appHistory| and |ongoingNavigation|.
      <p class="note">If |navigationType| is "{{AppHistoryNavigationType/traverse}}", then we will [=finalize with an aborted navigation error=] in [=perform an app history traversal=].
   1. Return |shouldContinue|.
 </div>
@@ -1174,14 +1173,12 @@ The <dfn attribute for="AppHistoryDestination">sameDocument</dfn> getter steps a
 <div algorithm>
   To <dfn>finalize with an aborted navigation error</dfn> given an {{AppHistory}} |appHistory|, an [=app history API navigation=] or null |ongoingNavigation|, and an optional {{DOMException}} |error|:
 
-  1. Let |signal| be null.
   1. If |appHistory|'s [=AppHistory/ongoing navigate event=] is non-null, then:
-    1. Set |signal| to the value of |appHistory|'s [=AppHistory/ongoing navigate event=]'s {{AppHistoryNavigateEvent/signal}} property.
     1. Set |appHistory|'s [=AppHistory/ongoing navigate event=]'s [=Event/canceled flag=] to true.
     1. Set |appHistory|'s [=AppHistory/ongoing navigate event=] to null.
-  1. Otherwise, set |signal| to |appHistory|'s [=AppHistory/post-navigate event ongoing navigation signal=].
-  1. Set |appHistory|'s [=AppHistory/post-navigate event ongoing navigation signal=] to null.
-  1. If |signal| is not null, then [=AbortSignal/signal abort=] on |signal|.
+  1. If |appHistory|'s [=AppHistory/ongoing navigation signal=] is non-null, then:
+    1. [=AbortSignal/Signal abort=] on |appHistory|'s [=AppHistory/ongoing navigation signal=].
+    1. Set |appHistory|'s [=AppHistory/ongoing navigation signal=] to null.
   1. If |error| was not given, then set |error| to a [=new=] "{{AbortError}}" {{DOMException}}, created in |appHistory|'s [=relevant Realm=].
   1. If |appHistory|'s [=AppHistory/transition=] is not null, then:
     1. [=Reject=] |appHistory|'s [=AppHistory/transition=]'s [=AppHistoryTransition/finished promise=] with |error|.
@@ -1192,13 +1189,14 @@ The <dfn attribute for="AppHistoryDestination">sameDocument</dfn> getter steps a
     1. [=Reject=] |ongoingNavigation|'s [=app history API navigation/returned promise=] with |error|.
     1. Perform |ongoingNavigation|'s [=app history API navigation/cleanup step=].
   1. [=Fire an event=] named {{AppHistory/navigateerror}} at |appHistory| using {{ErrorEvent}}, with {{ErrorEvent/error}} initialized to |error|, and {{ErrorEvent/message}}, {{ErrorEvent/filename}}, {{ErrorEvent/lineno}}, and {{ErrorEvent/colno}} initialized to appropriate values that can be extracted from |error| and the current JavaScript stack in the same underspecified way the user agent typically does for the <a spec="HTML">report an exception</a> algorithm.
-    <p class="note">Thus, for example, if this algorithm is reached because of a call to {{Window/stop()|window.stop()}}, these properties would probably end up initialized based on the line of script that called {{Window/stop()|window.stop()}}. But if it's because the user clicked the stop button, these properties would probably end up with default values like the empty string or 0.
+     <p class="note">Thus, for example, if this algorithm is reached because of a call to {{Window/stop()|window.stop()}}, these properties would probably end up initialized based on the line of script that called {{Window/stop()|window.stop()}}. But if it's because the user clicked the stop button, these properties would probably end up with default values like the empty string or 0.
 </div>
 
 <div algorithm>
   To <dfn>inform app history about canceling navigation</dfn> in a [=browsing context=] |bc|:
 
   1. Let |appHistory| be |bc|'s [=browsing context/active window=]'s [=Window/app history=].
+  1. If |appHistory|'s [=AppHistory/ongoing navigation signal=] is null, then return.
   1. Let |ongoingNavigation| be |appHistory|'s [=AppHistory/ongoing non-traverse navigation=].
   1. If |ongoingNavigation| is null, and the navigation being canceled is an "<a for="history handling behavior">`entry update`</a>" navigation that originally came from traversal to a [=session history entry=] |she|, then:
     <p class="advisement">This predicate should be made more precise when we define navigation cancelation in detail.</p>
@@ -1211,6 +1209,7 @@ The <dfn attribute for="AppHistoryDestination">sameDocument</dfn> getter steps a
   To <dfn>inform app history about canceling traversals</dfn> in a [=browsing context=] |bc|:
 
   1. Let |appHistory| be |bc|'s [=browsing context/active window=]'s [=Window/app history=].
+  1. If |appHistory|'s [=AppHistory/ongoing navigation signal=] is null, then return.
   1. Let |traversals| be a [=list/clone=] of |appHistory|'s [=AppHistory/ongoing traverse navigations=].
   1. For each |ongoingTraversal| of |traversals|: [=finalize with an aborted navigation error=] given |appHistory| and |ongoingTraversal|.
 </div>


### PR DESCRIPTION
Follows https://chromium-review.googlesource.com/c/chromium/src/+/3102875 and https://chromium-review.googlesource.com/c/chromium/src/+/3104346, although the spec's "inform app history about canceling navigation" / "inform app history about canceling traversals" don't quite map to the implementation.

By introducing a guard in those algorithms that checks for the ongoing navigation signal, this fixes a spec bug where we would sometimes fire navigateerror even if there's no ongoing navigation (e.g. if window.stop() is called).


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/app-history/pull/156.html" title="Last updated on Aug 18, 2021, 11:22 PM UTC (486d069)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/app-history/156/f647fa4...486d069.html" title="Last updated on Aug 18, 2021, 11:22 PM UTC (486d069)">Diff</a>