### PR TITLE
Ignore the promise content on `transitionWhile()`

### DIFF
--- a/app_history.d.ts
+++ b/app_history.d.ts
@@ -100,7 +100,7 @@ declare class AppHistoryNavigateEvent extends Event {
   readonly formData: FormData|null;
   readonly info: unknown;
 
-  transitionWhile(newNavigationAction: Promise<void>): void;
+  transitionWhile(newNavigationAction: Promise<any>): void;
 }
 
 interface AppHistoryNavigateEventInit extends EventInit {


### PR DESCRIPTION
I think this change would make sense since the promise content is not used and without it things like this fail in TS:

```ts
function doAsyncStuff() {
  return fetchSomething().then(data => {
    storeData(data)
    return data // so it can be used with const data = await doAsyncStuff()
  })
}

event.transitionWhile(doAsyncStuff())
```