### PR TITLE
Disable most of the API on opaque origins

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -190,6 +190,20 @@ dictionary AppHistoryResult {
 };
 </xmp>
 
+<div algorithm>
+  An {{AppHistory}} |appHistory| <dfn for="AppHistory">has entries and events disabled</dfn> if the following steps return true:
+
+  1. Let |browsingContext| be |appHistory|'s [=relevant global object=]'s [=Window/browsing context=].
+
+  1. If |browsingContext| is null, then return true.
+
+  1. If |browsingContext| is <a spec="HTML">still on its initial `about:blank` `Document`</a>, then return true.
+
+  1. If |appHistory|'s [=relevant global object=]'s [=associated Document=]'s [=Document/origin=] is [=opaque origin|opaque=], then return true.
+
+  1. Return false.
+</div>
+
 <h3 id="entries-api">Introspecting the app history entry list</h3>
 
 <dl class="domintro non-normative">
@@ -216,7 +230,7 @@ Each {{AppHistory}} object has an associated <dfn for="AppHistory">current index
 <div algorithm>
   The <dfn method for="AppHistory">entries()</dfn> method steps are:
 
-  1. If [=this=]'s [=relevant global object=]'s [=associated Document=] is not [=Document/fully active=], then return the empty list.
+  1. If [=this=] [=AppHistory/has entries and events disabled=], then return the empty list.
 
   1. Return [=this=]'s [=AppHistory/entries list=].
 </div>
@@ -224,9 +238,9 @@ Each {{AppHistory}} object has an associated <dfn for="AppHistory">current index
 <div algorithm>
   The <dfn attribute for="AppHistory">canGoBack</dfn> getter steps are:
 
-  1. If [=this=]'s [=relevant global object=]'s [=associated Document=] is not [=Document/fully active=], then return false.
+  1. If [=this=] [=AppHistory/has entries and events disabled=], then return false.
 
-  1. If [=this=]'s [=AppHistory/current index=] is &minus;1, then return false.
+  1. Assert: [=this=]'s [=AppHistory/current index=] is not &minus;1.
 
   1. If [=this=]'s [=AppHistory/current index=] is 0, then return false.
 
@@ -236,9 +250,9 @@ Each {{AppHistory}} object has an associated <dfn for="AppHistory">current index
 <div algorithm>
   The <dfn attribute for="AppHistory">canGoForward</dfn> getter steps are:
 
-  1. If [=this=]'s [=relevant global object=]'s [=associated Document=] is not [=Document/fully active=], then return false.
+  1. If [=this=] [=AppHistory/has entries and events disabled=], then return false.
 
-  1. If [=this=]'s [=AppHistory/current index=] is &minus;1, then return false.
+  1. Assert: [=this=]'s [=AppHistory/current index=] is not &minus;1.
 
   1. If [=this=]'s [=AppHistory/current index=] is equal to [=this=]'s [=AppHistory/entry list=]'s [=list/size=] &minus; 1, then return false.
 
@@ -248,19 +262,13 @@ Each {{AppHistory}} object has an associated <dfn for="AppHistory">current index
 <div algorithm>
   To <dfn for="AppHistory">update the entries</dfn> for an {{AppHistory}} instance |appHistory|:
 
-  1. Let |browsingContext| be |appHistory|'s [=relevant global object=]'s [=Window/browsing context=].
-
-  1. [=Assert=]: |browsingContext| is not null.
-
-  1. Let |sessionHistory| be |browsingContext|'s [=session history=].
-
-  1. If |browsingContext| is <a spec="HTML">still on its initial `about:blank` `Document`</a>, then:
+  1. If |appHistory| [=AppHistory/has entries and events disabled=], then:
 
     1. Assert: |appHistory|'s [=AppHistory/entry list=] [=list/is empty=].
 
     1. Return.
 
-    <p class="note">This can occur if running the <a spec="HTML">URL and history update steps</a>, e.g. via {{Document/open(unused1, unused2)|document.open()}}, on the initial `about:blank` {{Document}}. The app history API chooses not to expose the initial `about:blank` {{Document}}, so we bail early.
+  1. Let |sessionHistory| be |appHistory|'s [=relevant global object=]'s [=Window/browsing context=]'s [=session history=].
 
   1. Let |appHistorySHEs| be a new empty list.
 
@@ -370,11 +378,9 @@ Each {{AppHistory}} object has an associated <dfn for="AppHistory">current index
 <div algorithm>
   The <dfn for="AppHistory">current entry</dfn> for an {{AppHistory}} |appHistory| is the result running of the following algorithm:
 
-  1. If |appHistory|'s [=relevant global object=]'s [=associated Document=] is not [=Document/fully active=], then return null.
+  1. If [=this=] [=AppHistory/has entries and events disabled=], then return null.
 
-  1. If |appHistory|'s [=AppHistory/current index=] is &minus;1, then return null.
-
-     <p class="note">This occurs if accessing the API while on the initial `about:blank` {{Document}}, where the [=AppHistory/update the entries=] algorithm will not yet have been run to completion.
+  1. Assert: [=this=]'s [=AppHistory/current index=] is not &minus;1.
 
   1. Return |appHistory|'s [=AppHistory/entry list=][|appHistory|'s [=AppHistory/current index=]].
 </div>
@@ -1209,7 +1215,7 @@ The <dfn attribute for="AppHistoryDestination">sameDocument</dfn> getter steps a
   1. If either |userInvolvement| is not "<code>[=user navigation involvement/browser UI=]</code>" or  |navigationType| is not "{{AppHistoryNavigationType/traverse}}", then initialize |event|'s {{Event/cancelable}} to true. Otherwise, initialize it to false.
   1. If both |event|'s {{AppHistoryNavigateEvent/canTransition}} and |event|'s {{Event/cancelable}} are false, then return true.
      <p class="note">In this case we are definitely performing a cross-document navigation or traversal. We don't clean up |ongoingNavigation| however, since we might end up [=finalizing with an aborted navigation error=] before the current {{Document}} unloads.
-  1. If |appHistory|'s [=relevant global object=]'s [=Window/browsing context=] is <a spec="HTML">still on its initial `about:blank` `Document`</a>, then:
+  1. If |appHistory| [=AppHistory/has entries and events disabled=], then:
     1. If |ongoingNavigation| is not null, then [=app history API navigation/clean up=] |ongoingNavigation|.
        <p class="note">In this case the [=app history API navigation/committed promise=] and [=app history API navigation/finished promise=] will never fulfill, since we never create {{AppHistoryEntry}}s for the initial `about:blank` {{Document}} so we have nothing to [=resolve=] them with.
     1. Return true.


### PR DESCRIPTION
Closes #167.

/cc @annevk @jakearchibald


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/app-history/pull/169.html" title="Last updated on Sep 23, 2021, 7:15 PM UTC (cae4289)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/app-history/169/1d50439...cae4289.html" title="Last updated on Sep 23, 2021, 7:15 PM UTC (cae4289)">Diff</a>