### PR TITLE
Explainer for focus management and scroll restoration

### DIFF
--- a/app_history.d.ts
+++ b/app_history.d.ts
@@ -96,7 +96,7 @@ interface AppHistoryReloadOptions extends AppHistoryNavigationOptions {
 }
 
 declare class AppHistoryCurrentChangeEvent extends Event {
-  constructor(type: string, eventInit: AppHistoryCurrentChangeEventInit);
+  constructor(type: string, eventInit?: AppHistoryCurrentChangeEventInit);
 
   readonly navigationType: AppHistoryNavigationType|null;
   readonly from: AppHistoryEntry;
@@ -108,7 +108,7 @@ interface AppHistoryCurrentChangeEventInit extends EventInit {
 }
 
 declare class AppHistoryNavigateEvent extends Event {
-  constructor(type: string, eventInit: AppHistoryNavigateEventInit);
+  constructor(type: string, eventInit?: AppHistoryNavigateEventInit);
 
   readonly navigationType: AppHistoryNavigationType;
   readonly canTransition: boolean;
@@ -119,7 +119,7 @@ declare class AppHistoryNavigateEvent extends Event {
   readonly formData: FormData|null;
   readonly info: unknown;
 
-  transitionWhile(newNavigationAction: Promise<any>): void;
+  transitionWhile(newNavigationAction: Promise<any>, options?: AppHistoryTransitionWhileOptions): void;
 }
 
 interface AppHistoryNavigateEventInit extends EventInit {
@@ -131,6 +131,11 @@ interface AppHistoryNavigateEventInit extends EventInit {
   signal: AbortSignal;
   formData?: FormData|null;
   info?: unknown;
+}
+
+interface AppHistoryTransitionWhileOptions {
+  focusReset?: "after-transition"|"manual",
+  scrollRestoration?: "after-transition"|"manual"
 }
 
 declare class AppHistoryDestination {


### PR DESCRIPTION
This also rearranges some of the content around accessibility technology announcements and loading spinners/stop buttons, grouping them all under a new section "Customizations and consequences of navigation interception".

Still a few TODOs for next week, thus leaving this in a draft state. But the plan is for this PR to address #187, #190, and #25.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/app-history/pull/197.html" title="Last updated on Jan 27, 2022, 10:43 PM UTC (8affd6a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/app-history/197/ff79291...8affd6a.html" title="Last updated on Jan 27, 2022, 10:43 PM UTC (8affd6a)">Diff</a>